### PR TITLE
Add label "namespace" to PrometheusRule

### DIFF
--- a/charts/sophora-export-job/Chart.yaml
+++ b/charts/sophora-export-job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-export-job/values.yaml
+++ b/charts/sophora-export-job/values.yaml
@@ -84,6 +84,7 @@ prometheusRule:
       expr: sophora_export_job_exported_documents{job="{{ include "sophora-export-job.fullname" . }}"} == 0
       labels:
         severity: warning
+        namespace: "{{ .Release.Namespace }}"
       annotations:
         description: 'Sophora export job ({{ "{{ $labels.job }}" }}) did not export any documents'
         summary: 'The job did not export any documents'
@@ -92,6 +93,7 @@ prometheusRule:
       expr: max(vector(0) or sophora_export_job_end{success="false", job="{{ include "sophora-export-job.fullname" . }}"}) > max(vector(0) or sophora_export_job_end{success="true", job="{{ include "sophora-export-job.fullname" . }}"})
       labels:
         severity: critical
+        namespace: "{{ .Release.Namespace }}"
       annotations:
         description: 'Sophora export job failed.'
         summary: 'The export job ({{ include "sophora-export-job.fullname" . }}) did not complete successfully.'
@@ -100,6 +102,7 @@ prometheusRule:
       expr: (time() - push_time_seconds{job="{{ include "sophora-export-job.fullname" . }}"}) / (60 * 60) > 24
       labels:
         severity: warning
+        namespace: "{{ .Release.Namespace }}"
       annotations:
         description: 'Sophora export job ({{ "{{ $labels.job }}" }}) did not update metrics in the last 24 hours'
         summary: 'The job did not update metrics in the last 24 hours.'

--- a/charts/sophora-import-job/Chart.yaml
+++ b/charts/sophora-import-job/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-import-job/values.yaml
+++ b/charts/sophora-import-job/values.yaml
@@ -126,6 +126,7 @@ prometheusRule:
       expr: abs(sum by (job) (sophora_import_job_downloaded_documents{job="{{ include "sophora-import-job.fullname" . }}"}) - sum by(job) (sophora_import_job_imported_documents{imported="true", job="{{ include "sophora-import-job.fullname" . }}"})) > 0
       labels:
         severity: error
+        namespace: "{{ .Release.Namespace }}"
       annotations:
         description: 'Sophora import job ({{ "{{ $labels.job }}" }}) did not import some documents: {{ "{{ $value }}" }} '
         summary: 'The import job downloaded more files than it imported successfully.'
@@ -134,6 +135,7 @@ prometheusRule:
       expr: sophora_import_job_downloaded_documents{job="{{ include "sophora-import-job.fullname" . }}"} == 0
       labels:
         severity: warning
+        namespace: "{{ .Release.Namespace }}"
       annotations:
         description: 'Sophora import job ({{ "{{ $labels.job }}" }}) did not download any documents.'
         summary: 'The import job did not find any documents in the downloaded archives and hence cannot import anything.'
@@ -142,6 +144,7 @@ prometheusRule:
       expr: max(vector(0) or sophora_import_job_end{success="false", job="{{ include "sophora-import-job.fullname" . }}"}) > max(vector(0) or sophora_import_job_end{success="true", job="{{ include "sophora-import-job.fullname" . }}"})
       labels:
         severity: critical
+        namespace: "{{ .Release.Namespace }}"
       annotations:
         description: 'Sophora import job ({{ "{{ $labels.job }}" }}) failed.'
         summary: 'The import job ({{ include "sophora-import-job.fullname" . }}) did not complete successfully.'


### PR DESCRIPTION
Sometimes, alerts triggered by Prometheus do not have the correct namespace or no namespace at all.
This PR adds an explicit label "namespace" to the PrometheusRules of `sophora-export-job` and `sophora-import-job`.