### PR TITLE
schema-docs: use ClusterIP instead of NodePort

### DIFF
--- a/charts/sophora-schema-docs/Chart.yaml
+++ b/charts/sophora-schema-docs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-schema-docs
 description: Sophora Schema Docs
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 4.0.0

--- a/charts/sophora-schema-docs/values.yaml
+++ b/charts/sophora-schema-docs/values.yaml
@@ -67,9 +67,8 @@ schemaDocs:
   extraEnv:
 
 service:
-  type: NodePort
-  clusterPort: 8080
-  nodePort: 8080
+  type: ClusterIP
+  port: 8080
   annotations: {}
 
 ingress:


### PR DESCRIPTION
This PR changes the chart for Schema Docs to use ClusterIP again instead of NodePort.