### PR TITLE
schema-docs: use correct values for service port again

### DIFF
--- a/charts/sophora-schema-docs/Chart.yaml
+++ b/charts/sophora-schema-docs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-schema-docs
 description: Sophora Schema Docs
 type: application
-version: 2.0.1
+version: 2.0.2
 appVersion: 4.0.0

--- a/charts/sophora-schema-docs/templates/service.yaml
+++ b/charts/sophora-schema-docs/templates/service.yaml
@@ -15,5 +15,4 @@ spec:
   ports:
     - protocol: TCP
       targetPort: http
-      port: {{ .Values.service.clusterPort }}
-      nodePort: {{ .Values.service.nodePort }}
+      port: {{ .Values.service.port }}


### PR DESCRIPTION
This PR fixes the service definition for Schema Docs so that it uses the correct values for the service's port.