### PR TITLE
[sophora-dashboard] introduce global value for "registry"

### DIFF
--- a/charts/sophora-admin-dashboard/templates/statefulset.yaml
+++ b/charts/sophora-admin-dashboard/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       initContainers:
         - name: config-generator
-          image: "{{ .Values.registry }}/{{ .Values.configGenerator.image.repository }}:{{ .Values.configGenerator.image.tag }}"
+          image: "{{ .Values.global.imageRegistry }}/{{ .Values.configGenerator.image.repository }}:{{ .Values.configGenerator.image.tag }}"
           imagePullPolicy: {{ .Values.configGenerator.image.pullPolicy }}
           env:
             - name: SERVER_SOPHORAUSERNAME
@@ -96,7 +96,7 @@ spec:
               mountPath: /dashboard-config
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.global.imageRegistry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/sophora-admin-dashboard/templates/statefulset.yaml
+++ b/charts/sophora-admin-dashboard/templates/statefulset.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       initContainers:
         - name: config-generator
-          image: "{{ .Values.configGenerator.image.repository }}:{{ .Values.configGenerator.image.tag }}"
+          image: "{{ .Values.registry }}/{{ .Values.configGenerator.image.repository }}:{{ .Values.configGenerator.image.tag }}"
           imagePullPolicy: {{ .Values.configGenerator.image.pullPolicy }}
           env:
             - name: SERVER_SOPHORAUSERNAME
@@ -96,7 +96,7 @@ spec:
               mountPath: /dashboard-config
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/sophora-admin-dashboard/values.yaml
+++ b/charts/sophora-admin-dashboard/values.yaml
@@ -1,9 +1,11 @@
 # -- (int) number of replicas/pods in the statefulset
 replicaCount: 1
 
+registry: docker.subshell.com
+
 image:
   # -- (string) image repository
-  repository: docker.subshell.com/sophora/sophora-dashboard
+  repository: sophora/sophora-dashboard
   # -- (string) the k8s image pull policy
   pullPolicy: IfNotPresent
   # -- (string) overrides the image tag
@@ -28,7 +30,7 @@ hostAliases:
 
 configGenerator:
   image:
-    repository: "docker.subshell.com/misc/alpine-toolkit"
+    repository: "misc/alpine-toolkit"
     tag: "0.0.1"
     pullPolicy: IfNotPresent
 

--- a/charts/sophora-admin-dashboard/values.yaml
+++ b/charts/sophora-admin-dashboard/values.yaml
@@ -1,7 +1,9 @@
+global:
+  # -- (string) image registry
+  imageRegistry: docker.subshell.com
+
 # -- (int) number of replicas/pods in the statefulset
 replicaCount: 1
-
-registry: docker.subshell.com
 
 image:
   # -- (string) image repository


### PR DESCRIPTION
Makes it much easier to override the default registry. Otherwise one would have to override each and every declaration of `repository`. Far worse, new entries would go undetected if not checked externally with e.g. Kyverno.

This change should be applied to all charts.

`kube-prometheus-stack` has a similar approach leveraging `global.imageRegistry`: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L223