### PR TITLE
Only run job "release" in "subshell/helm-charts"

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'subshell/helm-charts'}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Prevent job to run in forks

See: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository