### PR TITLE
[sophora-image-ai] mount configuration in the correct location

### DIFF
--- a/charts/sophora-image-ai/Chart.yaml
+++ b/charts/sophora-image-ai/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-image-ai
 description: Sophora Image AI
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 4.0.0

--- a/charts/sophora-image-ai/templates/deployment.yaml
+++ b/charts/sophora-image-ai/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config
-              mountPath: /config
+              mountPath: /app/config
               readOnly: true
             - name: gcp-credentials
               mountPath: /gcp-credentials


### PR DESCRIPTION
This PR fixes a bug in the Helm chart for Sophora Image AI where the configuration inside the container was mounted at an incorrect location.