### PR TITLE
[sophora-schema-docs] mount configuration at the correct location

### DIFF
--- a/charts/sophora-schema-docs/Chart.yaml
+++ b/charts/sophora-schema-docs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-schema-docs
 description: Sophora Schema Docs
 type: application
-version: 2.1.0
+version: 2.1.1
 appVersion: 4.1.0

--- a/charts/sophora-schema-docs/templates/deployment.yaml
+++ b/charts/sophora-schema-docs/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
               {{- if eq (.Values.image.tag | default .Chart.AppVersion) "4.0.0" }}
               mountPath: /data/config
               {{ else }}
-              mountPath: /config
+              mountPath: /app/config
               {{ end -}}
               readOnly: true
           ports:


### PR DESCRIPTION
This PR fixes a bug in the Helm chart for Sophora Schema Docs where the configuration inside the container was mounted at an incorrect location.