### PR TITLE
[sophora-image-ai] mount configuration at the correct location for earlier app versions

### DIFF
--- a/charts/sophora-image-ai/Chart.yaml
+++ b/charts/sophora-image-ai/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-image-ai
 description: Sophora Image AI
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: 4.0.0

--- a/charts/sophora-image-ai/Chart.yaml
+++ b/charts/sophora-image-ai/Chart.yaml
@@ -3,4 +3,4 @@ name: sophora-image-ai
 description: Sophora Image AI
 type: application
 version: 1.0.2
-appVersion: 4.0.0
+appVersion: 5.1.0

--- a/charts/sophora-image-ai/templates/deployment.yaml
+++ b/charts/sophora-image-ai/templates/deployment.yaml
@@ -31,11 +31,11 @@ spec:
               # 4.0.0, 4.1.0, 5.0.0, and 5.1.0 are the only versions that use WORKDIR /
               {{- if eq (.Values.image.tag | default .Chart.AppVersion) "4.0.0" }}
               mountPath: /config
-              {{- else if eq (.Values.image.tag | default .Chart.AppVersion) "4.1.0" }}
+              {{ else if eq (.Values.image.tag | default .Chart.AppVersion) "4.1.0" }}
               mountPath: /config
-              {{- else if eq (.Values.image.tag | default .Chart.AppVersion) "5.0.0" }}
+              {{ else if eq (.Values.image.tag | default .Chart.AppVersion) "5.0.0" }}
               mountPath: /config
-              {{- else if eq (.Values.image.tag | default .Chart.AppVersion) "5.1.0" }}
+              {{ else if eq (.Values.image.tag | default .Chart.AppVersion) "5.1.0" }}
               mountPath: /config
               {{ else }}
               mountPath: /app/config

--- a/charts/sophora-image-ai/templates/deployment.yaml
+++ b/charts/sophora-image-ai/templates/deployment.yaml
@@ -28,7 +28,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           volumeMounts:
             - name: config
+              # 4.0.0, 4.1.0, 5.0.0, and 5.1.0 are the only versions that use WORKDIR /
+              {{- if eq (.Values.image.tag | default .Chart.AppVersion) "4.0.0" }}
+              mountPath: /config
+              {{- else if eq (.Values.image.tag | default .Chart.AppVersion) "4.1.0" }}
+              mountPath: /config
+              {{- else if eq (.Values.image.tag | default .Chart.AppVersion) "5.0.0" }}
+              mountPath: /config
+              {{- else if eq (.Values.image.tag | default .Chart.AppVersion) "5.1.0" }}
+              mountPath: /config
+              {{ else }}
               mountPath: /app/config
+              {{ end -}}
               readOnly: true
             - name: gcp-credentials
               mountPath: /gcp-credentials

--- a/charts/sophora-image-ai/values.yaml
+++ b/charts/sophora-image-ai/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: docker.subshell.com/sophora/imageai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "4.0.0"
+  tag: "5.1.0"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This PR is a followup on #99 to mount the configuration inside the container at the correct location for earlier versions of the app.