### PR TITLE
[sophora-schema-docs] mount configuration at the correct location for earlier app versions

### DIFF
--- a/charts/sophora-schema-docs/Chart.yaml
+++ b/charts/sophora-schema-docs/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-schema-docs
 description: Sophora Schema Docs
 type: application
-version: 2.1.1
-appVersion: 4.1.0
+version: 2.1.2
+appVersion: 5.0.0

--- a/charts/sophora-schema-docs/templates/deployment.yaml
+++ b/charts/sophora-schema-docs/templates/deployment.yaml
@@ -28,9 +28,15 @@ spec:
           args: ["--dynamic"]
           volumeMounts:
             - name: config
-              # 4.0.0 is the only version that uses WORKDIR /data
+              # 4.0.0 uses WORKDIR /data
               {{- if eq (.Values.image.tag | default .Chart.AppVersion) "4.0.0" }}
               mountPath: /data/config
+              # 4.1.0 uses WORKDIR /
+              {{ else if eq (.Values.image.tag | default .Chart.AppVersion) "4.1.0" }}
+              mountPath: /config
+              # 5.0.0 uses WORKDIR /
+              {{ else if eq (.Values.image.tag | default .Chart.AppVersion) "5.0.0" }}
+              mountPath: /config
               {{ else }}
               mountPath: /app/config
               {{ end -}}

--- a/charts/sophora-schema-docs/values.yaml
+++ b/charts/sophora-schema-docs/values.yaml
@@ -5,7 +5,7 @@ image:
   repository: docker.subshell.com/sophora/schemadoc
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "4.0.0"
+  tag: "5.0.0"
 
 imagePullSecrets: []
 


### PR DESCRIPTION
This PR is a followup on #100 to mount the configuration inside the container at the correct location for earlier versions of the app.