### PR TITLE
[linkchecker] fixed placeholder key in application.yaml

### DIFF
--- a/charts/sophora-linkchecker/Chart.yaml
+++ b/charts/sophora-linkchecker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-linkchecker
 description: Sophora Link Checker
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 6.0.0

--- a/charts/sophora-linkchecker/values.yaml
+++ b/charts/sophora-linkchecker/values.yaml
@@ -28,7 +28,7 @@ sophora:
           username: # in secret
           password: # in secret
 
-    linkchecker:
+    link-checker:
 
 startupProbe:
   failureThreshold: 15


### PR DESCRIPTION
The configuration prefix used by the Linkchecker application is "link-checker".