### PR TITLE
[sophora-server] add grpc ingress option

### DIFF
--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.0
+version: 2.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/README.md
+++ b/charts/sophora-server/README.md
@@ -17,6 +17,15 @@ For all other configuration options use `sophora.server.properties`.
 
 It's also possible to use postgres as your jcr repository. To use postgres with jcr set `sophora.server.persistence.repositoryType` to `postgres`.
 
+## gRPC API (Sophora v6+)
+Sophora 6 introduces a gRPC API. gRPC is basically HTTP/2 but requires specific non-default settings in most HTTP proxies, including Ingress Controllers.
+To deal with this, the chart now supports deploying a second Ingress for the gRPC API, which can be configured differently from the main Ingress.
+
+This is not enabled by default.
+To enable it, set `grpcIngress.enabled` to `true` and configure it as needed.
+The example configuration contains the required
+settings for the Nginx Ingress Controller.
+
 ## Tips for productive installations
 
 ### Cluster servers
@@ -154,6 +163,10 @@ sophora.persistence.postgres.port=5432
 **Note**: For cluster servers we still recommend a separate postgres deployment, like Google Cloud SQL.
 
 ## Notable Changes
+
+## 2.5.0
+
+This version of the Chart now supports deploying a second Ingress with the purpose to host the gRPC API, which is coming in Sophora 6.
 
 ## 2.1.0
 Updates the pre-stop hook to version 2.0.0 and configures it accordingly.

--- a/charts/sophora-server/templates/grpc-ingress.yaml
+++ b/charts/sophora-server/templates/grpc-ingress.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.grpcIngress.enabled -}}
+  {{- $fullName := include "sophora-server.fullname" . -}}
+  {{- $ingressName := printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
+  {{- $svcPort := .Values.service.httpPort -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $ingressName }}
+  labels:
+  {{- include "sophora-server.labels" . | nindent 4 }}
+  {{- with .Values.grpcIngress.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.grpcIngress.ingressClassName }}
+  ingressClassName: {{ .Values.grpcIngress.ingressClassName }}
+  {{- end -}}
+  {{- if .Values.grpcIngress.tls }}
+  tls:
+    {{- range .Values.grpcIngress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.grpcIngress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: {{ .path }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+  {{- end }}
+  {{- end }}

--- a/charts/sophora-server/test-values.yaml
+++ b/charts/sophora-server/test-values.yaml
@@ -111,6 +111,16 @@ ingress:
   hosts:
     - host: "sophora.domain.de"
 
+grpcIngress:
+  enabled: true
+  ingressClassName: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  hosts:
+    - host: "sophora.domain.de"
+      path: /sophora\.grpc.*
+
 extraDeploy:
   - |
     apiVersion: keda.sh/v1alpha1

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -329,6 +329,25 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# This can be used to configure a different ingress for the gRPC service as gRPC may require different settings,
+# e.g. nginx needs to be explicitly informed that the backend protocol is gRPC and that the path should be regex-matched.
+grpcIngress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  annotations: {}
+  # kubernetes.io/tls-acme: "true"
+  # nginx.ingress.kubernetes.io/use-regex: "true"
+  # nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+  hosts:
+  # - host: chart-example.local
+  #   path: /sophora\.grpc.*
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
 service:
   annotations: {}
   headlessAnnotations: {}


### PR DESCRIPTION
This adds an option to the Server Helm Chart that allows deploying a second ingress to configure gRPC connections. Using this may be necessary starting with Sophora Server v6, which adds a gRPC API.