### PR TITLE
[sophora-importer] update logback configuration for Spring 6 compatibility

### DIFF
--- a/charts/sophora-importer/Chart.yaml
+++ b/charts/sophora-importer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.1
+version: 1.3.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-importer/values.yaml
+++ b/charts/sophora-importer/values.yaml
@@ -78,14 +78,12 @@ logbackXml: |
       <jmxConfigurator/>
   
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-          <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
-              <evaluator>
-                  <!-- No log messages marked as 'SPECIAL_EMAIL_NOTIFICATION' should be shown. -->
-                  <expression>marker != null &amp;&amp; marker.getName().equals("SPECIAL_EMAIL_NOTIFICATION")</expression>
-              </evaluator>
+          <!-- No log messages marked as 'SPECIAL_EMAIL_NOTIFICATION' should be shown. -->
+          <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+              <Marker>SPECIAL_EMAIL_NOTIFICATION</Marker>
               <OnMismatch>NEUTRAL</OnMismatch>
               <OnMatch>DENY</OnMatch>
-          </filter>
+          </turboFilter>
           <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
       </appender>
   


### PR DESCRIPTION
Relates to UNSOI-2211.
Spring 6 uses logback-classic 1.4.14 which no longer supports the context variable `event` and causes the application to fail on startup. 

Similar to the Spring 6 Update in sophora-importer, we change the filter to `<turboFilter>`. 
This chart's appVersion is set to `4.11.0` and doesn't need to be updated because the sophora-importer 4.11.0 uses logback-classic 1.2.12 which already contains `ch.qos.logback.classic.turbo.MarkerFilter` for the turboFilter. 