### PR TITLE
[sophora-server] [sophora-cluster-common] Add label "namespace" to PrometheusRules

### DIFF
--- a/charts/sophora-cluster-common/Chart.yaml
+++ b/charts/sophora-cluster-common/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: sophora-cluster-common
 description: A Helm chart containing some common resources useful for Sophora cloud setups
 type: application
-version: 1.2.1
+version: 1.3.0
 appVersion: "4"

--- a/charts/sophora-cluster-common/templates/alerts/prometheusrule.yaml
+++ b/charts/sophora-cluster-common/templates/alerts/prometheusrule.yaml
@@ -15,6 +15,7 @@ spec:
           expr: 'absent(sophora_server_replication_mode == 1)'
           labels:
             severity: critical
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: The Sophora Cluster has no primary.
             description: No primary server elected in the cluster.
@@ -24,6 +25,7 @@ spec:
           expr: 'max(sophora_server_source_time and sophora_server_is_primary_server == 1) - ignoring(pod) group_right max by (pod) (sophora_server_source_time and sophora_server_state == 2) > 60000'
           labels:
             severity: high
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Server is not in sync
             description: The server  "{{`{{ $labels.pod }}`}}" is not in sync.
@@ -33,6 +35,7 @@ spec:
           expr: 'count(sophora_server_replication_mode == 1) > 1'
           labels:
             severity: critical
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: The Sophora Cluster has more than one server claiming to be the primary.
             description: There are two primary servers in the cluster.

--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.6.0
+version: 2.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/templates/prometheusrule.yaml
+++ b/charts/sophora-server/templates/prometheusrule.yaml
@@ -15,6 +15,7 @@ spec:
           expr: 'up{container="sophora-server", job="{{ include "sophora-server.fullname" . }}"} != 1'
           labels:
             severity: high
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora Server offline.
             description: The server "{{`{{ $labels.service }}`}}" is offline for more than 10 minutes.
@@ -24,6 +25,7 @@ spec:
           expr: 'histogram_quantile(0.95, sum(rate(sophora_server_contentmanager_call_duration_seconds_bucket{job="{{ include "sophora-server.fullname" . }}"}[1m])) by (pod, le)) > 0.5'
           labels:
             severity: high
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora Server API is slow
             description: The API of the server "{{`{{ $labels.pod }}`}}" exhibits a response time exceeding 500ms for more than 15 minutes at the 95th percentile.
@@ -33,6 +35,7 @@ spec:
           expr: 'sophora_server_events_number_of_asyc_events_waiting_to_be_processed{job="{{ include "sophora-server.fullname" . }}"} > 10000'
           labels:
             severity: high
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora Server event processing is slow or blocked
             description: The internal event queue of the server "{{`{{ $labels.pod }}`}}" exceeds a size of 10,000 for more than 10m.
@@ -43,6 +46,7 @@ spec:
           expr: 'sophora_server_state{job="{{ include "sophora-server.fullname" . }}"} == -1'
           labels:
             severity: medium
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: State of Sophora server is unknown
             description: State of Sophora server "{{`{{ $labels.pod }}`}}" is unknown
@@ -52,6 +56,7 @@ spec:
           expr: 'sophora_server_state{job="{{ include "sophora-server.fullname" . }}"} == 3'
           labels:
             severity: medium
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora server's synchronization is delayed
             description: The synchronization to the server server "{{`{{ $labels.pod }}`}}" is delayed.
@@ -61,6 +66,7 @@ spec:
           expr: 'sophora_server_state{job="{{ include "sophora-server.fullname" . }}"} == 4'
           labels:
             severity: medium
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora server's queue is too long
             description: The server "{{`{{ $labels.pod }}`}}" is not up-to-date due to a too long queue.
@@ -70,6 +76,7 @@ spec:
           expr: 'sophora_server_state{job="{{ include "sophora-server.fullname" . }}"} == 5'
           labels:
             severity: high
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora server unavailable
             description: The server "{{`{{ $labels.pod }}`}}" unavailable and the cause should be investigated
@@ -79,6 +86,7 @@ spec:
           expr: 'sophora_server_state{job="{{ include "sophora-server.fullname" . }}"} == 6'
           labels:
             severity: high
+            namespace: "{{ .Release.Namespace }}"
           annotations:
             summary: Sophora server lost connection to primary
             description: The server "{{`{{ $labels.pod }}`}}" is disconnected from its primary server


### PR DESCRIPTION
Sometimes, alerts triggered by Prometheus do not have the correct namespace or no namespace at all.
This PR adds an explicit label "namespace" to the PrometheusRules of `sophora-server` and `sophora-cluster-common`.

See #38.