### PR TITLE
[sophora-ugc] UNSO-1979: add support for service accounts

### DIFF
--- a/charts/sophora-ugc/CHANGELOG.md
+++ b/charts/sophora-ugc/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.6
+- Add support for service accounts
+
 ## 2.0.3
 
 - Add S3 submission connection for UGC

--- a/charts/sophora-ugc/Chart.yaml
+++ b/charts/sophora-ugc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.5
+version: 2.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-ugc/templates/_helpers.tpl
+++ b/charts/sophora-ugc/templates/_helpers.tpl
@@ -54,10 +54,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "sophora-ugc.serviceAccountName" -}}
-{{- if .Values.config.serviceAccount.create }}
-{{- default (include "sophora-ugc.fullname" .) .Values.config.serviceAccount.name }}
+{{- if .Values.ugc.serviceAccount.create }}
+{{- default (include "sophora-ugc.fullname" .) .Values.ugc.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.config.serviceAccount.name }}
+{{- default "default" .Values.ugc.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/charts/sophora-ugc/templates/_helpers.tpl
+++ b/charts/sophora-ugc/templates/_helpers.tpl
@@ -51,6 +51,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "sophora-ugc.serviceAccountName" -}}
+{{- if .Values.config.serviceAccount.create }}
+{{- default (include "sophora-ugc.fullname" .) .Values.config.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.config.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "sophora-ugc-multimedia.chart" -}}

--- a/charts/sophora-ugc/templates/serviceaccount.yaml
+++ b/charts/sophora-ugc/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sophora-ugc.serviceAccountName" . }}
+  labels:
+    {{- include "sophora-ugc.labels" . | nindent 4 }}
+  {{- with .Values.config.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.config.serviceAccount.automount }}
+{{- end }}

--- a/charts/sophora-ugc/templates/serviceaccount.yaml
+++ b/charts/sophora-ugc/templates/serviceaccount.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.config.serviceAccount.create -}}
+{{- if .Values.ugc.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "sophora-ugc.serviceAccountName" . }}
   labels:
     {{- include "sophora-ugc.labels" . | nindent 4 }}
-  {{- with .Values.config.serviceAccount.annotations }}
+  {{- with .Values.ugc.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-automountServiceAccountToken: {{ .Values.config.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.ugc.serviceAccount.automount }}
 {{- end }}

--- a/charts/sophora-ugc/test-values.yaml
+++ b/charts/sophora-ugc/test-values.yaml
@@ -129,6 +129,10 @@ ugc:
           memory: "2Gi"
           cpu: "1"
 
+  serviceAccount:
+    create: true
+    annotations:
+      iam.gke.io/gcp-service-account: sophora-ugc@account
 
 ugcMultimedia:
   enabled: true

--- a/charts/sophora-ugc/values.yaml
+++ b/charts/sophora-ugc/values.yaml
@@ -102,7 +102,17 @@ ugc:
 
   extraContainers: []
   extraInitContainers: []
-  serviceAccount: []
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: false
+    # Automatically mount a ServiceAccount's API credentials?
+    automount: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
 
 ugcMultimedia:
   enabled: false

--- a/charts/sophora-ugc/values.yaml
+++ b/charts/sophora-ugc/values.yaml
@@ -102,6 +102,7 @@ ugc:
 
   extraContainers: []
   extraInitContainers: []
+  serviceAccount: []
 
 ugcMultimedia:
   enabled: false


### PR DESCRIPTION
This adds service accounts to be used e.g. in conjunction with db-sidecars for accessing the database