### PR TITLE
external-secrets: Update API for externals-secrets >= v0.16.0

### DIFF
--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -9,4 +9,4 @@ annotations:
       description: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`.
       links:
         - name: GitHub Issue
-          url: https://github.com/subshell/helm-charts/issues/133
+          url: https://github.com/subshell/helm-charts/pull/164

--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -6,7 +6,7 @@ version: 2.0.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`.
+      description: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`. Upgrade existing releases to use this version of the chart prior to using external-secrets-operator >= v0.17.0.
       links:
         - name: GitHub Issue
           url: https://github.com/subshell/helm-charts/pull/164

--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -2,5 +2,11 @@ apiVersion: v2
 name: external-secrets
 description: A Helm chart for creating multiple external secrets
 type: application
-version: 1.0.1
-appVersion: 0.8.1
+version: 2.0.0
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`.
+      links:
+        - name: GitHub Issue
+          url: https://github.com/subshell/helm-charts/issues/133

--- a/charts/external-secrets/README.md
+++ b/charts/external-secrets/README.md
@@ -21,4 +21,4 @@ externalSecrets:
 
 # Changelog
 
-- ! Change: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`.
+- ! Change: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`. Upgrade existing releases to use this version of the chart prior to using external-secrets-operator >= v0.17.0.

--- a/charts/external-secrets/README.md
+++ b/charts/external-secrets/README.md
@@ -18,3 +18,7 @@ externalSecrets:
 - `name` of the Kubernetes secret to create.
 - `data[0].key` is the identifier in the remote store which holds the secret value.
 - `data[0].name` the secret key of the Kubernetes secret to receive the value.
+
+# Changelog
+
+- ! Change: Since chart version 2.0.0 requires external-secrets >= v0.16.0 (released April 2025) to use the `v1` apis instead of `v1beta1`.

--- a/charts/external-secrets/templates/external_secret.yaml
+++ b/charts/external-secrets/templates/external_secret.yaml
@@ -1,5 +1,5 @@
 {{- range .Values.externalSecrets }}
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   name: {{ .name }}


### PR DESCRIPTION
see https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0