### PR TITLE
Make SUBMISSIONS_S3_SECRETACCESSKEY optional for deployment of sophor…

### DIFF
--- a/charts/sophora-ugc/Chart.yaml
+++ b/charts/sophora-ugc/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.8
+version: 2.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-ugc/templates/deployment.yaml
+++ b/charts/sophora-ugc/templates/deployment.yaml
@@ -86,6 +86,7 @@ spec:
                 secretKeyRef:
                   key: {{ .Values.authentication.secret.s3bucket.secretIdKey }}
                   name: {{ .Values.authentication.secret.s3bucket.name }}
+                  optional: true
             {{- end }}
             {{ if .Values.env -}}
             {{- toYaml .Values.env | nindent 12 }}

--- a/charts/sophora-ugc/templates/deployment.yaml
+++ b/charts/sophora-ugc/templates/deployment.yaml
@@ -46,7 +46,6 @@ spec:
                 secretKeyRef:
                   key: {{ .Values.authentication.secret.server.usernameKey }}
                   name: {{ .Values.authentication.secret.server.name }}
-                  optional: true
             {{- end }}
             {{- if .Values.authentication.secret.server.passwordKey }}
             - name: SOPHORA-SERVER_PASSWORD
@@ -54,7 +53,6 @@ spec:
                 secretKeyRef:
                   key: {{ .Values.authentication.secret.server.passwordKey }}
                   name: {{ .Values.authentication.secret.server.name }}
-                  optional: true
             {{- end }}
             {{- if .Values.authentication.secret.database.usernameKey }}
             - name: DATABASE_USER
@@ -62,7 +60,6 @@ spec:
                 secretKeyRef:
                   key: {{ .Values.authentication.secret.database.usernameKey }}
                   name: {{ .Values.authentication.secret.database.name }}
-                  optional: true
             {{- end }}
             {{- if .Values.authentication.secret.database.passwordKey }}
             - name: DATABASE_PASSWORD
@@ -70,7 +67,6 @@ spec:
                 secretKeyRef:
                   key: {{ .Values.authentication.secret.database.passwordKey }}
                   name: {{ .Values.authentication.secret.database.name }}
-                  optional: true
             {{- end }}
             {{- if .Values.authentication.secret.s3bucket.accessKeyKey }}
             - name: SUBMISSIONS_S3_ACCESSKEYID


### PR DESCRIPTION
Using S3 for UGC is optional as far as i know (we do not use it for our non-cloud-infra currently). Thus  the secretRef for SUBMISSIONS_S3_SECRETACCESSKEY should be optional (as SUBMISSIONS_S3_ACCESSKEYID already is)