### PR TITLE
add defaults for application.yaml to sophora-ugc values

### DIFF
--- a/charts/sophora-ugc/values.yaml
+++ b/charts/sophora-ugc/values.yaml
@@ -99,6 +99,15 @@ ugc:
       host: 
     database:
       url:
+    logging:
+      config: /config/logback/logback.xml
+    spring:
+      main:
+        banner-mode: off
+      security:
+        user:
+          name: user
+
 
   extraContainers: []
   extraInitContainers: []


### PR DESCRIPTION
Adds defaults to application.yaml of sophora-ugc:

- adds reference to injected logback.xml
- add defaults required by spring-security (without them the application terminates with an exception)
- disable banner-mode (not useful when scraping logs)