### PR TITLE
[sophora-ugc] use named ports for ugc services and ingress

### DIFF
--- a/charts/sophora-ugc/templates/deployment.yaml
+++ b/charts/sophora-ugc/templates/deployment.yaml
@@ -88,10 +88,11 @@ spec:
             {{- toYaml .Values.env | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: {{ default 8080 (.Values.ugc.config.server).port }}
-              name: webapp
-            - containerPort: 1694
-              name: jolokia
+            {{ $httpPort := dig "server" "port" 9080 .Values.ugc.config }}
+            - containerPort: {{ $httpPort }}
+              name: webapp-http
+            - containerPort: {{ dig "management" "server" "port" $httpPort .Values.ugc.config }}
+              name: webapp-jolokia
           volumeMounts:
             - name: logback-xml
               mountPath: /config/logback

--- a/charts/sophora-ugc/templates/ingress.yaml
+++ b/charts/sophora-ugc/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
               service:
                 name: {{ $ugcFullName }}-webapp
                 port:
-                  number: {{ default 8080 ($.Values.ugc.config.server).port }}
+                  name: webapp-http
           {{- if $.Values.ugcMultimedia.enabled }}
           - path: /public/binary
             pathType: {{ default "ImplementationSpecific" .pathType }}
@@ -40,35 +40,35 @@ spec:
               service:
                 name: {{ $ugcMultimediaFullName }}
                 port:
-                  number: {{ default 8080 ($.Values.ugcMultimedia.config.server).port }}
+                  name: ugc-multimedia
           - path: /public/multimedia
             pathType: {{ default "ImplementationSpecific" .pathType }}
             backend:
               service:
                 name: {{ $ugcMultimediaFullName }}
                 port:
-                  number: {{ default 8080 ($.Values.ugcMultimedia.config.server).port }}
+                  name: ugc-multimedia
           - path: /secure/binary
             pathType: {{ default "ImplementationSpecific" .pathType }}
             backend:
               service:
                 name: {{ $ugcMultimediaFullName }}
                 port:
-                  number: {{ default 8080 ($.Values.ugcMultimedia.config.server).port }}
+                  name: ugc-multimedia
           - path: /secure/multimedia
             pathType: {{ default "ImplementationSpecific" .pathType }}
             backend:
               service:
                 name: {{ $ugcMultimediaFullName }}
                 port:
-                  number: {{ default 8080 ($.Values.ugcMultimedia.config.server).port }}
+                  name: ugc-multimedia
           - path: /websocket/multimedia
             pathType: {{ default "ImplementationSpecific" .pathType }}
             backend:
               service:
                 name: {{ $ugcMultimediaFullName }}
                 port:
-                  number: {{ default 8080 ($.Values.ugcMultimedia.config.server).port }}
+                  name: ugc-multimedia
           {{- end }}
     {{- end }}
     {{- end }}

--- a/charts/sophora-ugc/templates/jolokia-service.yaml
+++ b/charts/sophora-ugc/templates/jolokia-service.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   clusterIP: {{ .Values.service.jolokia.clusterIP }}
   ports:
-    - port: 1694
-      targetPort: 1694
+    - name: webapp-jolokia
+      port: 1694
+      targetPort: webapp-jolokia
       protocol: TCP
-      name: jolokia
   selector:
     {{- include "sophora-ugc.selectorLabels" . | nindent 4 }}

--- a/charts/sophora-ugc/templates/ugc-multimedia/multimedia-service.yaml
+++ b/charts/sophora-ugc/templates/ugc-multimedia/multimedia-service.yaml
@@ -13,8 +13,9 @@ spec:
   type: {{ .Values.service.webapp.type }}
   loadBalancerIP: {{ .Values.service.webapp.loadBalancerIP }}
   ports:
-    - port: 80
-      targetPort: {{ default 8080 (.Values.ugcMultimedia.config.server).port }}
+    - name: ugc-multimedia
+      port: 80
+      targetPort: ugc-multimedia
       protocol: TCP
   selector:
     {{- include "sophora-ugc-multimedia.selectorLabels" . | nindent 4 }}

--- a/charts/sophora-ugc/templates/ugc-multimedia/statefulset.yaml
+++ b/charts/sophora-ugc/templates/ugc-multimedia/statefulset.yaml
@@ -73,7 +73,7 @@ spec:
             {{- toYaml .Values.env | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: {{ default 8080 (.Values.ugcMultimedia.config.server).port }}
+            - containerPort: {{ dig "server" "port" 9080 .Values.ugcMultimedia.config }}
               name: ugc-multimedia
           volumeMounts:
             - name: logback-xml

--- a/charts/sophora-ugc/templates/webapp-service.yaml
+++ b/charts/sophora-ugc/templates/webapp-service.yaml
@@ -12,8 +12,9 @@ spec:
   type: {{ .Values.service.webapp.type }}
   loadBalancerIP: {{ .Values.service.webapp.loadBalancerIP }}
   ports:
-    - port: 80
-      targetPort: {{ default 8080 (.Values.ugc.config.server).port }}
+    - name: webapp-http
+      port: 80
+      targetPort: webapp-http
       protocol: TCP
   selector:
     {{- include "sophora-ugc.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
Changes services and ingress of ugc to use named ports where possible. So that port numbers need to be configured once only.