### PR TITLE
[sophora-ai] add configuration for Shorten for Infoscreen feature

### DIFF
--- a/charts/sophora-ai/Chart.yaml
+++ b/charts/sophora-ai/Chart.yaml
@@ -2,7 +2,11 @@ apiVersion: v2
 name: sophora-ai
 description: Sophora AI
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: 1.0.0
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/sophora-ai
+annotations:
+  artifacthub.io/changes: |
+    - kind: added
+      description: Added configuration for Shorten for Infoscreen feature

--- a/charts/sophora-ai/templates/configmap.yaml
+++ b/charts/sophora-ai/templates/configmap.yaml
@@ -34,6 +34,9 @@ data:
   application-sentiment.yaml: |- {{ toYaml (required "sophora.configuration.sentiment is required in values" .Values.sophora.configuration.sentiment) | nindent 4 }}
   application-shorten.yaml: |- {{ toYaml (required "sophora.configuration.shorten is required in values" .Values.sophora.configuration.shorten) | nindent 4 }}
   application-shorten-teletext.yaml: |- {{ toYaml (required "sophora.configuration.shortenTeletext is required in values" .Values.sophora.configuration.shortenTeletext) | nindent 4 }}
+  {{- if .Values.sophora.configuration.shortenInfoscreen }}
+  application-shorten-infoscreen.yaml: |- {{ toYaml .Values.sophora.configuration.shortenInfoscreen | nindent 4 }}
+  {{- end }}
   application-summarize.yaml: |- {{ toYaml (required "sophora.configuration.summarize is required in values" .Values.sophora.configuration.summarize) | nindent 4 }}
   application-teaser.yaml: |- {{ toYaml (required "sophora.configuration.teaser is required in values" .Values.sophora.configuration.teaser) | nindent 4 }}
   application-title.yaml: |- {{ toYaml (required "sophora.configuration.title is required in values" .Values.sophora.configuration.title) | nindent 4 }}

--- a/charts/sophora-ai/test-values.yaml
+++ b/charts/sophora-ai/test-values.yaml
@@ -108,6 +108,8 @@ sophora:
       testing: true
     shortenTeletext:
       testing: true
+    shortenInfoscreen:
+      testing: true
     summarize:
       testing: true
     teaser:

--- a/charts/sophora-ai/values.yaml
+++ b/charts/sophora-ai/values.yaml
@@ -153,6 +153,9 @@ sophora:
     # contents of application-shorten-teletext.yaml
     shortenTeletext:
 
+    # contents of application-shorten-infoscreen.yaml (actually required, but optional to support older app versions)
+    #shortenInfoscreen:
+
     # contents of application-summarize.yaml
     summarize:
 


### PR DESCRIPTION
This PR adds configuration support for the Shorten for Infoscreen feature which has been added to Sophora AI.

Note: Although this new part of the configuration is actually required to run Sophora AI, the chart will support it as optional to allow running older app versions. This way, users of the chart will not need to change their configuration as long as they are not upgrading the app version.