### PR TITLE
Add option to use sidecar to add xsl-files

### DIFF
--- a/charts/sophora-importer/Chart.yaml
+++ b/charts/sophora-importer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 2.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-importer/README.md
+++ b/charts/sophora-importer/README.md
@@ -23,9 +23,9 @@ Use `s3://` for folders that should be saved in an S3 bucket as configured with 
 
 ## Import transformation files via S3 or HTTP
 
-Activate transformations with by setting `transformation.enabled` to `true`. Now you can reference one or more zip files via s3 or http
-download (use `transformation.data.use` to set your preferred method. Defaults to s3).
-By default, all xsl files should be located in `xsl` and all lib files in `libs` inside the .zip file. 
+Activate transformations with by setting `transformation.enabled` to `true`. Now you can reference one or more zip files to download via s3 or http 
+or a sidecar-container, containing the files in directories. Use `transformation.data.use` to set your preferred method. Defaults to s3.
+By default, all xsl files should be located in `xsl` and all lib files in `libs` inside the .zip file or the sidecar-container 
 All possible configurations are available in `values.yaml`. Enabling transformations will create 
 the following directories, that can be accessed within the importer configuration:
 

--- a/charts/sophora-importer/templates/statefulset.yaml
+++ b/charts/sophora-importer/templates/statefulset.yaml
@@ -110,7 +110,8 @@ spec:
       initContainers:
       {{/* Transformations Download */}}
       {{- with .Values.transformation }}
-      {{- if and .enabled (eq .data.use "s3") }}
+      {{- if .enabled }}
+      {{- if eq .data.use "s3" }}
       - name: transformation-data-via-s3-downloader
         image: "{{ $.Values.downloadViaS3Image.repository }}:{{ $.Values.downloadViaS3Image.tag }}"
         imagePullPolicy: {{ $.Values.downloadViaS3Image.pullPolicy }}
@@ -140,8 +141,7 @@ spec:
             mountPath: {{ include "sophora-importer.transformationXslPath" . }}
           - name: libs
             mountPath: {{ include "sophora-importer.transformationLibsPath" . }}
-      {{- end }}
-      {{- if and .enabled (eq .data.use "http") }}
+      {{- else if eq .data.use "http" }}
       - name: transformation-data-via-http-downloader
         image: "{{ $.Values.downloadViaS3Image.repository }}:{{ $.Values.downloadViaS3Image.tag }}"
         imagePullPolicy: {{ $.Values.downloadViaS3Image.pullPolicy }}
@@ -167,8 +167,35 @@ spec:
             mountPath: {{ include "sophora-importer.transformationXslPath" . }}
           - name: libs
             mountPath: {{ include "sophora-importer.transformationLibsPath" . }}
+      {{- else if eq .data.use "sidecar" }}
+        - name: transformation-data-via-sidecar-copier
+          image: {{ tpl .data.sidecar.repository $ }}:{{ tpl .data.sidecar.tag $ }}
+          imagePullPolicy: {{ .data.sidecar.pullPolicy }}
+          volumeMounts:
+            - name: xsl
+              mountPath: {{ include "sophora-importer.transformationXslPath" . }}
+            - name: libs
+              mountPath: {{ include "sophora-importer.transformationLibsPath" . }}
+          env:
+            - name: XSL_FOLDER
+              value: {{ default "/xsl" .data.sidecar.folders.xsl }}
+            - name: LIBS_FOLDER
+              value: {{ default "/libs" .data.sidecar.folders.libs }}
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - |-
+              if [ -d "$XSL_FOLDER" ]; then
+                cp -r "$XSL_FOLDER"/* "{{ include "sophora-importer.transformationXslPath" . }}"
+                echo "copied xsl files to {{ include "sophora-importer.transformationXslPath" . }}"
+              fi
+              if [ -d "$LIBS_FOLDER" ]; then
+                cp -r "$LIBS_FOLDER"/* "{{ include "sophora-importer.transformationLibsPath" . }}"
+                echo "copied libs to {{ include "sophora-importer.transformationXslPath" . }}"
+              fi
         {{- end }}
-        {{- end }}
+      {{- end }}
+      {{- end }}
       volumes:
       - name: importer-config
         configMap:

--- a/charts/sophora-importer/values.yaml
+++ b/charts/sophora-importer/values.yaml
@@ -55,15 +55,15 @@ logbackXml: |
   <?xml version="1.0" encoding="UTF-8"?>
   <configuration scan="true" scanPeriod="60 seconds">
       <jmxConfigurator/>
-  
+
       <appender name="jsonConsoleAppender" class="ch.qos.logback.core.ConsoleAppender">          
           <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
       </appender>
-  
+
       <logger name="com.subshell.sophora" level="INFO"/>
       <logger name="com.subshell.sophora.importer" level="INFO"/>
       <logger name="org.springframework.boot" level="INFO"/>
-  
+
       <root level="WARN">
           <appender-ref ref="jsonConsoleAppender"/>
       </root>
@@ -86,6 +86,11 @@ transformation:
       zipPaths:
       secretAccessKeyKey: "secretAccessKey"
       accessKeyIdKey: "accessKeyId"
+    sidecar:
+      pullPolicy: IfNotPresent
+      folders:
+        xsl: "/xsl"
+        libs: "/libs"
     useSaxon: false
     saxonLicenceSecretName: "saxon-license"
     saxonLicenceSecretKey: "saxon-license.lic"
@@ -114,7 +119,6 @@ ingress:
   annotations: {}
   hosts:
   tls: []
-
 
 # There is the option of setting up the importer container with additionalVolumes and additionalVolumeMounts.
 # In this case the volumeMount and the volume must be used together and be configured in the same way (e.g. have the same name).


### PR DESCRIPTION
Adds the option "sidecar" to .Values.transformation.data which allows to copy xsl-files and required libs from a sidecar-/init-container. Works like the plugins-sidecar in the media-finder-chart.

Allows to template image-repository and tag to re-use global image-catalogs (as we use at SWR)