### PR TITLE
[sophora-ai] add configuration for Proofread feature

### DIFF
--- a/charts/sophora-ai/Chart.yaml
+++ b/charts/sophora-ai/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-ai
 description: Sophora AI
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.0.0
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/sophora-ai
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: Added configuration for Shorten for Infoscreen feature
+      description: Added configuration for Proofread feature

--- a/charts/sophora-ai/templates/configmap.yaml
+++ b/charts/sophora-ai/templates/configmap.yaml
@@ -26,6 +26,9 @@ data:
   application-keywords.yaml: |- {{ toYaml (required "sophora.configuration.keywords is required in values" .Values.sophora.configuration.keywords) | nindent 4 }}
   application-llm.yaml: |- {{ toYaml (required "sophora.configuration.llm is required in values" .Values.sophora.configuration.llm) | nindent 4 }}
   application-named-entities.yaml: |- {{ toYaml (required "sophora.configuration.namedEntities is required in values" .Values.sophora.configuration.namedEntities) | nindent 4 }}
+  {{- if .Values.sophora.configuration.proofread }}
+  application-proofread.yaml: |- {{ toYaml .Values.sophora.configuration.proofread | nindent 4 }}
+  {{- end }}
   application-questions.yaml: |- {{ toYaml (required "sophora.configuration.questions is required in values" .Values.sophora.configuration.questions) | nindent 4 }}
   application-quotations.yaml: |- {{ toYaml (required "sophora.configuration.quotations is required in values" .Values.sophora.configuration.quotations) | nindent 4 }}
   application-recommend-documents.yaml: |- {{ toYaml (required "sophora.configuration.recommendDocuments is required in values" .Values.sophora.configuration.recommendDocuments) | nindent 4 }}

--- a/charts/sophora-ai/test-values.yaml
+++ b/charts/sophora-ai/test-values.yaml
@@ -92,6 +92,8 @@ sophora:
       testing: true
     namedEntities:
       testing: true
+    proofread:
+      testing: true
     questions:
       testing: true
     quotations:

--- a/charts/sophora-ai/values.yaml
+++ b/charts/sophora-ai/values.yaml
@@ -129,6 +129,9 @@ sophora:
     # contents of application-named-entities.yaml
     namedEntities:
 
+    # contents of application-proofread.yaml (actually required, but optional to support older app versions)
+    #proofread:
+
     # contents of application-questions.yaml
     questions:
 


### PR DESCRIPTION
This PR adds configuration support for the Proofread feature which has been added to Sophora AI.

Note: Although this new part of the configuration is actually required to run Sophora AI, the chart will support it as optional to allow running older app versions. This way, users of the chart will not need to change their configuration as long as they are not upgrading the app version.