### PR TITLE
[sophora-server] bump chart version

### DIFF
--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.0
+version: 2.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
In #174, the chart for sophora-server has been changed without bumping the chart version. Consequently, the "Release Charts" workflow tried to update the existing chart version with new content, which failed.

This PR bumps the sophora-server chart version to fix the workflow.