### PR TITLE
[sophora-image-ai] add support for Google ADC

### DIFF
--- a/charts/sophora-image-ai/Chart.yaml
+++ b/charts/sophora-image-ai/Chart.yaml
@@ -2,5 +2,11 @@ apiVersion: v2
 name: sophora-image-ai
 description: Sophora Image AI
 type: application
-version: 1.0.2
+version: 2.0.0
 appVersion: 5.1.0
+sources:
+  - https://github.com/subshell/helm-charts/tree/main/charts/sophora-image-ai
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: Added support for Google Application Default Credentials (ADC). The 'sophora-image-ai-gcp-credentials' secret (name was hard-coded) is no longer required, but a secret containing the credentials can still be used. See values.yaml for details.

--- a/charts/sophora-image-ai/templates/deployment.yaml
+++ b/charts/sophora-image-ai/templates/deployment.yaml
@@ -41,9 +41,10 @@ spec:
               mountPath: /app/config
               {{ end -}}
               readOnly: true
-            - name: gcp-credentials
-              mountPath: /gcp-credentials
-              readOnly: true
+
+            {{- with .Values.extraVolumeMounts}}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               protocol: TCP
@@ -82,6 +83,7 @@ spec:
         - name: config
           configMap:
             name: {{ include "sophora-image-ai.fullname" . }}
-        - name: gcp-credentials
-          secret:
-            secretName: sophora-image-ai-gcp-credentials
+
+        {{- with .Values.extraVolumes}}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/sophora-image-ai/test-values.yaml
+++ b/charts/sophora-image-ai/test-values.yaml
@@ -29,12 +29,10 @@ sophora:
           # GCP project ID
           project-id: my-project
 
-          credentials:
-            # path to GCP credentials file - do not change
-            location: file:/gcp-credentials/credentials.json
-
 imageAI:
   extraEnv:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /gcp-credentials/credentials.json
 
 podAnnotations: {}
 
@@ -44,3 +42,13 @@ ingress:
   annotations: {}
   hosts:
   tls: []
+
+extraVolumes:
+  - name: gcp-credentials
+    secret:
+      secretName: sophora-image-ai-gcp-credentials
+
+extraVolumeMounts:
+  - name: gcp-credentials
+    mountPath: /gcp-credentials
+    readOnly: true

--- a/charts/sophora-image-ai/values.yaml
+++ b/charts/sophora-image-ai/values.yaml
@@ -34,11 +34,14 @@ sophora:
           # GCP project ID
           project-id: my-project
 
-          credentials:
-            # path to GCP credentials file - do not change
-            location: file:/gcp-credentials/credentials.json
-
 imageAI:
+  # Extra environment variables.
+  #
+  # Example extra environment variable to use a GCP credentials file from a secret.
+  # Use this in combination with extraVolumes and extraVolumeMounts.
+  #
+  # - name: GOOGLE_APPLICATION_CREDENTIALS
+  #   value: /gcp-credentials/credentials.json
   extraEnv:
 
 service:
@@ -54,5 +57,23 @@ ingress:
   tls: []
 
 extraDeploy: []
+
+# Extra volumes.
+#
+# Example extra volume to use a GCP credentials file from a secret:
+#
+# - name: gcp-credentials
+#   secret:
+#     secretName: sophora-image-ai-gcp-credentials
+extraVolumes: []
+
+# Extra volume mounts.
+#
+# Example extra volume mount to use a GCP credentials file from a secret:
+#
+# - name: gcp-credentials
+#   mountPath: /gcp-credentials
+#   readOnly: true
+extraVolumeMounts: []
 
 podAnnotations: {}


### PR DESCRIPTION
This PR adds support for [Google Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials?hl=en).

It is now optional to use a secret that contains the credentials file. Before, the chart required a secret named `sophora-image-ai-gcp-credentials` (hard-coded name.)

The chart's major version has been bumped to reflect this breaking change.