### PR TITLE
[sophora-ai] add support for Google ADC

### DIFF
--- a/charts/sophora-ai/Chart.yaml
+++ b/charts/sophora-ai/Chart.yaml
@@ -9,4 +9,4 @@ sources:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: Added support for Google Application Default Credentials (ADC). The 'sophora-image-ai-gcp-credentials' secret (name was hard-coded) is no longer required, but a secret containing the credentials can still be used. See values.yaml for details.
+      description: Added support for Google Application Default Credentials (ADC). A secret containing the credentials can still be used, see values.yaml for details.

--- a/charts/sophora-ai/Chart.yaml
+++ b/charts/sophora-ai/Chart.yaml
@@ -2,15 +2,11 @@ apiVersion: v2
 name: sophora-ai
 description: Sophora AI
 type: application
-version: 1.3.0
+version: 2.0.0
 appVersion: 1.0.0
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/sophora-ai
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: Added support for extra init containers and extra containers.
-    - kind: added
-      description: Added support for service account creation.
-    - kind: added
-      description: Added support for directly specifying a PostgresQL username in values.
+    - kind: changed
+      description: Added support for Google Application Default Credentials (ADC). The 'sophora-image-ai-gcp-credentials' secret (name was hard-coded) is no longer required, but a secret containing the credentials can still be used. See values.yaml for details.

--- a/charts/sophora-ai/templates/deployment.yaml
+++ b/charts/sophora-ai/templates/deployment.yaml
@@ -34,10 +34,8 @@ spec:
             - name: config
               mountPath: /app/config
               readOnly: true
-            {{- if .Values.sophora.gcpCredentials }}
-            - name: gcp-credentials
-              mountPath: /app/gcp-credentials
-              readOnly: true
+            {{- with .Values.extraVolumeMounts}}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           ports:
             - name: http
@@ -144,8 +142,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "sophora-ai.fullname" . }}
-        {{- if .Values.sophora.gcpCredentials }}
-        - name: gcp-credentials
-          secret:
-            secretName: {{ required "A valid secret name must be provided in .Values.sophora.gcpCredentials.secret.name" .Values.sophora.gcpCredentials.secret.name | quote }}
+        {{- with .Values.extraVolumes}}
+        {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/sophora-ai/test-values.yaml
+++ b/charts/sophora-ai/test-values.yaml
@@ -26,10 +26,6 @@ sophora:
         name: openai-credentials
         apiKeyKey: apiKey
 
-  gcpCredentials:
-    secret:
-      name: sophora-ai-gcp-credentials
-
   googleSearchCredentials:
     secret:
       name: google-search-credentials

--- a/charts/sophora-ai/test-values.yaml
+++ b/charts/sophora-ai/test-values.yaml
@@ -123,6 +123,8 @@ sophora:
 
 ai:
   extraEnv:
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: /gcp-credentials/credentials.json
 
 resources:
   requests:
@@ -146,3 +148,13 @@ serviceAccount:
   automount: true
   annotations:
     foo: bar
+
+extraVolumes:
+  - name: gcp-credentials
+    secret:
+      secretName: sophora-image-ai-gcp-credentials
+
+extraVolumeMounts:
+  - name: gcp-credentials
+    mountPath: /gcp-credentials
+    readOnly: true

--- a/charts/sophora-ai/values.yaml
+++ b/charts/sophora-ai/values.yaml
@@ -198,6 +198,13 @@ resources:
     memory: 1Gi
 
 ai:
+  # Extra environment variables.
+  #
+  # Example extra environment variable to use a GCP credentials file from a secret.
+  # Use this in combination with extraVolumes and extraVolumeMounts.
+  #
+  # - name: GOOGLE_APPLICATION_CREDENTIALS
+  #   value: /gcp-credentials/credentials.json
   extraEnv:
 
 service:
@@ -213,6 +220,24 @@ ingress:
   tls: []
 
 extraDeploy: []
+
+# Extra volumes.
+#
+# Example extra volume to use a GCP credentials file from a secret:
+#
+# - name: gcp-credentials
+#   secret:
+#     secretName: sophora-image-ai-gcp-credentials
+extraVolumes: []
+
+# Extra volume mounts.
+#
+# Example extra volume mount to use a GCP credentials file from a secret:
+#
+# - name: gcp-credentials
+#   mountPath: /gcp-credentials
+#   readOnly: true
+extraVolumeMounts: []
 
 podAnnotations: {}
 

--- a/charts/sophora-ai/values.yaml
+++ b/charts/sophora-ai/values.yaml
@@ -32,12 +32,6 @@ sophora:
   #      name: ""
   #      apiKeyKey: apiKey
 
-  # GCP credentials.json secret (optional)
-  # This secret must contain a 'credentials.json' key.
-  #gcpCredentials:
-  #  secret:
-  #    name: ""
-
   # Google Search credentials secret (optional)
   #googleSearchCredentials:
   #  secret:


### PR DESCRIPTION
This PR adds support for [Google Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials?hl=en).

It is now optional to use a secret that contains the credentials file. Before, the chart required to configure a secret name.

The chart's major version has been bumped to reflect this breaking change.

This PR mirrors the changes made in #190, but for sophora-ai.