### PR TITLE
[sophora-ai] actually use service account name in deployment descriptor

### DIFF
--- a/charts/sophora-ai/Chart.yaml
+++ b/charts/sophora-ai/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-ai
 description: Sophora AI
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.0.0
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/sophora-ai
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Added support for Google Application Default Credentials (ADC). A secret containing the credentials can still be used, see values.yaml for details.
+    - kind: fixed
+      description: The deployment descriptor now correctly uses the configured service account name.

--- a/charts/sophora-ai/templates/deployment.yaml
+++ b/charts/sophora-ai/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "sophora-ai.serviceAccountName" . }}
       {{- if .Values.extraInitContainers }}
       initContainers:
         {{ include "common.tplvalues.render" (dict "value" .Values.extraInitContainers "context" $) | nindent 8 }}


### PR DESCRIPTION
This PR changes the deployment descriptor of sophora-ai so that it actually uses the configured service account.