### PR TITLE
[sophora-image-ai] enable use of a service account

### DIFF
--- a/charts/sophora-image-ai/Chart.yaml
+++ b/charts/sophora-image-ai/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-image-ai
 description: Sophora Image AI
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: 5.1.0
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/sophora-image-ai
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: Added support for Google Application Default Credentials (ADC). The 'sophora-image-ai-gcp-credentials' secret (name was hard-coded) is no longer required, but a secret containing the credentials can still be used. See values.yaml for details.
+    - kind: added
+      description: Enabled the use of a service account.

--- a/charts/sophora-image-ai/templates/_helpers.tpl
+++ b/charts/sophora-image-ai/templates/_helpers.tpl
@@ -62,3 +62,14 @@ Usage:
         {{- tpl (.value | toYaml) .context }}
     {{- end }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "sophora-image-ai.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "sophora-image-ai.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/sophora-image-ai/templates/deployment.yaml
+++ b/charts/sophora-image-ai/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "sophora-image-ai.serviceAccountName" . }}
       containers:
         - name: image-ai
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/sophora-image-ai/templates/serviceaccount.yaml
+++ b/charts/sophora-image-ai/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sophora-image-ai.serviceAccountName" . }}
+  labels:
+    {{- include "sophora-image-ai.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/sophora-image-ai/test-values.yaml
+++ b/charts/sophora-image-ai/test-values.yaml
@@ -43,6 +43,12 @@ ingress:
   hosts:
   tls: []
 
+serviceAccount:
+  create: true
+  automount: true
+  annotations:
+    foo: bar
+
 extraVolumes:
   - name: gcp-credentials
     secret:

--- a/charts/sophora-image-ai/values.yaml
+++ b/charts/sophora-image-ai/values.yaml
@@ -77,3 +77,14 @@ extraVolumes: []
 extraVolumeMounts: []
 
 podAnnotations: {}
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
This PR adds the functionality necessary to use a service account when deploying Sophora Image AI.