### PR TITLE
[sophora-image-access-service] SIMSI-127: fix usage of new metrics port; keep orginal name of the default ingress 

### DIFF
--- a/charts/sophora-image-access-service/Chart.yaml
+++ b/charts/sophora-image-access-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.3.0
+version: 1.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-image-access-service/templates/deployment.yaml
+++ b/charts/sophora-image-access-service/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: metrics
             failureThreshold: {{ .failureThreshold }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
@@ -87,7 +87,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: metrics
             failureThreshold: {{ .failureThreshold }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}
@@ -97,7 +97,7 @@ spec:
           startupProbe:
             httpGet:
               path: /actuator/health
-              port: http
+              port: metrics
             failureThreshold: {{ .failureThreshold }}
             initialDelaySeconds: {{ .initialDelaySeconds }}
             periodSeconds: {{ .periodSeconds }}

--- a/charts/sophora-image-access-service/templates/ingress.yaml
+++ b/charts/sophora-image-access-service/templates/ingress.yaml
@@ -8,7 +8,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ $fullName }}-{{ $index }}
+  name: {{ $fullName }}{{ eq $index 0 | ternary "" (printf "-%d" $index) }}
   labels:
   {{- include "access-service.labels" $ | nindent 4 }}
   {{- with $ingress.annotations }}

--- a/charts/sophora-image-access-service/templates/servicemonitor.yaml
+++ b/charts/sophora-image-access-service/templates/servicemonitor.yaml
@@ -10,6 +10,6 @@ spec:
         matchLabels: {{- include "access-service.selectorLabels" . | nindent 12 }}
     endpoints:
         - interval: {{ .Values.serviceMonitor.interval }}
-          port: http
+          port: metrics
           path: {{ .Values.serviceMonitor.path }}
 {{- end }}

--- a/charts/sophora-image-access-service/tests/ingresses_test.yaml
+++ b/charts/sophora-image-access-service/tests/ingresses_test.yaml
@@ -17,7 +17,7 @@ tests:
           of: Ingress
       - equal:
           path: metadata.name
-          value: sophora-image-access-service-0
+          value: sophora-image-access-service
       - equal:
           path: metadata.annotations.ingress
           value: true


### PR DESCRIPTION
1. The new `metrics` port has not correctly been referenced in probes and ServiceMonitor
2. The name of the first (default) ingress should remain unchanged compared to chart versions < 1.2.0 to ensure updates in a running system without complications (otherwise, the "old" ingress will not be deleted by helm)