### PR TITLE
[sophora-cluster-common] Prometheus alerts check for Sophora Servers in a single namespace only

### DIFF
--- a/charts/sophora-cluster-common/Chart.yaml
+++ b/charts/sophora-cluster-common/Chart.yaml
@@ -2,5 +2,9 @@ apiVersion: v2
 name: sophora-cluster-common
 description: A Helm chart containing some common resources useful for Sophora cloud setups
 type: application
-version: 1.4.0
+version: 1.4.1
 appVersion: "4"
+annotations:
+  artifacthub.io/changes: |
+    - kind: fixed
+      description: Prometheus alerts check for Sophora Servers in a single namespace only.

--- a/charts/sophora-cluster-common/templates/alerts/prometheusrule.yaml
+++ b/charts/sophora-cluster-common/templates/alerts/prometheusrule.yaml
@@ -12,7 +12,7 @@ spec:
         {{- if $defaultRulesEnabled }}
         - alert: NoPrimarySophoraServer
           for: 1m
-          expr: 'absent(sophora_server_replication_mode == 1)'
+          expr: 'absent(sophora_server_replication_mode{namespace="{{ .Release.Namespace }}"} == 1)'
           labels:
             severity: critical
             namespace: "{{ .Release.Namespace }}"
@@ -22,7 +22,7 @@ spec:
             runbook_url: 'https://github.com/subshell/helm-charts/blob/main/charts/sophora-cluster-common/alerting-runbook.md'
         - alert: SophoraServerNotInSync
           for: 2m
-          expr: 'max(sophora_server_source_time and sophora_server_is_primary_server == 1) - ignoring(pod) group_right max by (pod) (sophora_server_source_time and sophora_server_state == 2) > 60000'
+          expr: 'max(sophora_server_source_time and sophora_server_is_primary_server{namespace="{{ .Release.Namespace }}"} == 1) - ignoring(pod) group_right max by (pod) (sophora_server_source_time and sophora_server_state{namespace="{{ .Release.Namespace }}"} == 2) > 60000'
           labels:
             severity: high
             namespace: "{{ .Release.Namespace }}"
@@ -32,7 +32,7 @@ spec:
             runbook_url: 'https://github.com/subshell/helm-charts/blob/main/charts/sophora-cluster-common/alerting-runbook.md'
         - alert: MultiplePrimarySophoraServers
           for: 1m
-          expr: 'count(sophora_server_replication_mode == 1) > 1'
+          expr: 'count(sophora_server_replication_mode{namespace="{{ .Release.Namespace }}"} == 1) > 1'
           labels:
             severity: critical
             namespace: "{{ .Release.Namespace }}"


### PR DESCRIPTION
This prevents triggering the alert `MultiplePrimarySophoraServers` when deploying in multiple namespaces in the same Kubernetes cluster.