### PR TITLE
[sophora-import-job] add `sophora.serverURLs` for multiple Sophor Server URL connections

### DIFF
--- a/charts/sophora-import-job/CHANGELOG.md
+++ b/charts/sophora-import-job/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.0
+
+- Allow the configuration of multiple Sophora Server URLs by providing a list to `sophora.serverUrls`. The value `sophora.serverUrl` is now deprecated and may be removed in future versions.
+
 ## 1.3.0
 
 - Make postStart and preStop hook configurable. 

--- a/charts/sophora-import-job/Chart.yaml
+++ b/charts/sophora-import-job/Chart.yaml
@@ -15,13 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "add possibility to execute commands before and after run-importer.sh script"
-    - kind: added
-      description: "upgrade aws-cli to a version with kubectl installed"
+      description: "multiple Server URLs can be provided as sophora.serverUrls"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-import-job/templates/configmap.yaml
+++ b/charts/sophora-import-job/templates/configmap.yaml
@@ -9,7 +9,9 @@ data:
     sophora:
       client:
         server-connection:
-          urls: {{.Values.sophora.serverUrl}}
+          {{- /* TODO deprecated backwards compatibility with `sophora.serverUrl` will be removed in the future */}}
+          {{- $sophoraUrls := coalesce .Values.sophora.serverUrls (list .Values.sophora.serverUrl) }}
+          urls: {{ $sophoraUrls | toYaml | nindent 12 }}
           username: # in secret
           password: # in secret
           retries: 15

--- a/charts/sophora-import-job/test-values.yaml
+++ b/charts/sophora-import-job/test-values.yaml
@@ -10,7 +10,9 @@ sophoraDocumentsDownload:
       - "https://software.subshell.com/two.zip"
 
 sophora:
-  serverUrl: http://sophora-server:1196
+  serverUrls:
+    - http://sophora-server1:1196
+    - http://sophora-server2:1196
   internalConnection: true
   useMigrationMode: true
   authentication:

--- a/charts/sophora-import-job/values.yaml
+++ b/charts/sophora-import-job/values.yaml
@@ -32,7 +32,9 @@ metrics:
       passwordKey: "password"
 
 sophora:
-  serverUrl:
+  serverUrls:
+  # deprecated for removal in future versions
+  #serverUrl:
   internalConnection: true
   useMigrationMode: false
   authentication:


### PR DESCRIPTION
Enables the connection to all cluster servers independent which is primary