### PR TITLE
[sophora-server]: only compute hash over actual ConfigMap data

### DIFF
--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.11.0
+version: 2.11.1
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "The statefulset now uses multiple checksum fields"
+      description: "ConfigMap checksums now only change if .data content changes."
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/README.md
+++ b/charts/sophora-server/README.md
@@ -216,6 +216,11 @@ sophora.persistence.postgres.port=5432
 
 ## Notable Changes
 
+### 2.11.1
+
+This version modifies how the `checksum/*` annotations in the StatefulSet's pod template are computed. Previously, the `sha256sum` was based on the _whole_ rendered ConfigMap, leading to changes in a hash whenever merely a ConfigMap label changed (like the `.Chart.AppVersion` or any user-provided `additionalSelectorLabels`). This did not affect the volume-mounted content seen by the pod, but still resulted in an update of the pod template and termination and restart of the StatefulSet's pods.
+This change only includes the `.data` portion of the ConfigMaps into the hash computation, such that changes to `.metadata` (like labels) don't affect the checksum.
+
 ### 2.10.0
 
 This version changes the configuration of the gRPC API since the latest pre-release versions of Sophora now run it on a separate port. The most notable change may be that

--- a/charts/sophora-server/templates/statefulset.yaml
+++ b/charts/sophora-server/templates/statefulset.yaml
@@ -30,20 +30,20 @@ spec:
       {{- if or (.Values.podAnnotations) (.Values.addChecksumAnnotation) }}
       annotations:
         {{- if .Values.addChecksumAnnotation }}
-        checksum/sophora-init-configmap: {{ include (print $.Template.BasePath "/sophora-init-configmap.yaml") . | sha256sum }}
-        checksum/logback-configmap: {{ include (print $.Template.BasePath "/logback-configmap.yaml") . | sha256sum }}
+        checksum/sophora-init-configmap: {{ get (include (print $.Template.BasePath "/sophora-init-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
+        checksum/logback-configmap: {{ get (include (print $.Template.BasePath "/logback-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
         {{- if ne .Values.sophora.server.persistence.archiveType "none" }}
-        checksum/sophora-archive-localdb-configmap: {{ include (print $.Template.BasePath "/sophora-archive-localdb-configmap.yaml") . | sha256sum }}
-        checksum/sophora-archive-mysql-configmap: {{ include (print $.Template.BasePath "/sophora-archive-mysql-configmap.yaml") . | sha256sum }}
+        checksum/sophora-archive-localdb-configmap: {{ get (include (print $.Template.BasePath "/sophora-archive-localdb-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
+        checksum/sophora-archive-mysql-configmap: {{ get (include (print $.Template.BasePath "/sophora-archive-mysql-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
         {{- end }}
         {{- if eq .Values.sophora.server.persistence.repositoryType "localdb" }}
-        checksum/sophora-repository-localdb-configmap: {{ include (print $.Template.BasePath "/sophora-repository-localdb-configmap.yaml") . | sha256sum }}
+        checksum/sophora-repository-localdb-configmap: {{ get (include (print $.Template.BasePath "/sophora-repository-localdb-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
         {{- end }}
         {{- if eq .Values.sophora.server.persistence.repositoryType "mysql" }}
-        checksum/sophora-repository-mysql-configmap: {{ include (print $.Template.BasePath "/sophora-repository-mysql-configmap.yaml") . | sha256sum }}
+        checksum/sophora-repository-mysql-configmap: {{ get (include (print $.Template.BasePath "/sophora-repository-mysql-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
         {{- end }}
         {{- if eq .Values.sophora.server.persistence.repositoryType "postgres" }}
-        checksum/sophora-repository-postgres-configmap: {{ include (print $.Template.BasePath "/sophora-repository-postgres-configmap.yaml") . | sha256sum }}
+        checksum/sophora-repository-postgres-configmap: {{ get (include (print $.Template.BasePath "/sophora-repository-postgres-configmap.yaml") . | fromYaml) "data" | toYaml | sha256sum }}
         {{- end }}
         {{- end }}
         {{- range $key, $value := .Values.podAnnotations }}


### PR DESCRIPTION
Currently, when merely the chart version changes, the hash will change and as such the sophora server pods will be recreated.
This is unnecessary, and should be avoided. The hash should only change if the actual `.data` of the ConfigMaps change.

This probably also fixes https://github.com/subshell/helm-charts/issues/203