### PR TITLE
[sophora-ai] add configuration for Reader Copy feature

### DIFF
--- a/charts/sophora-ai/Chart.yaml
+++ b/charts/sophora-ai/Chart.yaml
@@ -2,13 +2,13 @@ apiVersion: v2
 name: sophora-ai
 description: Sophora AI
 type: application
-version: 2.0.3
+version: 2.0.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "chart formatting"
+    - kind: added
+      description: added configuration for new Reader Copy feature
 
-appVersion: 1.0.0
+appVersion: 1.5.5
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/sophora-ai
 home: https://subshell.com/sophora/modules/sophora-ai100.html

--- a/charts/sophora-ai/templates/configmap.yaml
+++ b/charts/sophora-ai/templates/configmap.yaml
@@ -31,6 +31,9 @@ data:
   {{- end }}
   application-questions.yaml: |- {{ toYaml (required "sophora.configuration.questions is required in values" .Values.sophora.configuration.questions) | nindent 4 }}
   application-quotations.yaml: |- {{ toYaml (required "sophora.configuration.quotations is required in values" .Values.sophora.configuration.quotations) | nindent 4 }}
+  {{- if .Values.sophora.configuration.readerCopy }}
+  application-reader-copy.yaml: |- {{ toYaml .Values.sophora.configuration.readerCopy | nindent 4 }}
+  {{- end }}
   application-recommend-documents.yaml: |- {{ toYaml (required "sophora.configuration.recommendDocuments is required in values" .Values.sophora.configuration.recommendDocuments) | nindent 4 }}
   application-recommend-links.yaml: |- {{ toYaml (required "sophora.configuration.recommendLinks is required in values" .Values.sophora.configuration.recommendLinks) | nindent 4 }}
   application-rephrase.yaml: |- {{ toYaml (required "sophora.configuration.rephrase is required in values" .Values.sophora.configuration.rephrase) | nindent 4 }}

--- a/charts/sophora-ai/test-values.yaml
+++ b/charts/sophora-ai/test-values.yaml
@@ -94,6 +94,8 @@ sophora:
       testing: true
     quotations:
       testing: true
+    readerCopy:
+      testing: true
     recommendDocuments:
       testing: true
     recommendLinks:

--- a/charts/sophora-ai/values.yaml
+++ b/charts/sophora-ai/values.yaml
@@ -133,6 +133,9 @@ sophora:
     # contents of application-quotations.yaml
     quotations:
 
+    # contents of application-reader-copy.yaml (actually required, but optional to support older app versions)
+    #readerCopy:
+
     # contents of application-recommend-documents.yaml
     recommendDocuments:
 


### PR DESCRIPTION
This PR adds support for the upcoming Reader Copy feature in Sophora AI.

Note: The actual configuration in releases is optional to support older installations as well.