### PR TITLE
[external-secrets] SUDO-645: add support for 'dataFrom' secret extraction

### DIFF
--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: external-secrets
 description: A Helm chart for creating multiple external secrets
 type: application
-version: 2.0.2
+version: 2.1.0
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "chart formatting"
+    - kind: added
+      description: "support for 'dataFrom' secret extraction"
 
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/external-secrets

--- a/charts/external-secrets/templates/external_secret.yaml
+++ b/charts/external-secrets/templates/external_secret.yaml
@@ -16,10 +16,7 @@ spec:
     {{- end }}
   {{- if .dataFrom }}
   dataFrom:
-    {{- range .dataFrom }}
-    - extract:
-        key: {{ .key }}
-    {{ end }}
+    {{- toYaml .dataFrom | nindent 4 }}
   {{- else }}
   data:
     {{- range .data }}

--- a/charts/external-secrets/templates/external_secret.yaml
+++ b/charts/external-secrets/templates/external_secret.yaml
@@ -14,6 +14,13 @@ spec:
     template:
       type: {{ .type }}
     {{- end }}
+  {{- if .dataFrom }}
+  dataFrom:
+    {{- range .dataFrom }}
+    - extract:
+        key: {{ .key }}
+    {{ end }}
+  {{- else }}
   data:
     {{- range .data }}
     - secretKey: {{ .name }}
@@ -21,5 +28,6 @@ spec:
         key: {{ .key }}
         version: {{ .version | default "latest" }}
     {{- end }}
+  {{ end }}
 ---
 {{- end }}

--- a/charts/external-secrets/test-values.yaml
+++ b/charts/external-secrets/test-values.yaml
@@ -9,4 +9,5 @@ externalSecrets:
     version: latest
 - name: example-with-dataFrom
   dataFrom:
-    - key: example-key-with-json-value
+    - extract:
+        key: example-key-with-json-value

--- a/charts/external-secrets/test-values.yaml
+++ b/charts/external-secrets/test-values.yaml
@@ -7,3 +7,6 @@ externalSecrets:
   - key: example-key
     name: example-name
     version: latest
+- name: example-with-dataFrom
+  dataFrom:
+    - key: example-key-with-json-value


### PR DESCRIPTION
Add support for extracting multiple secrets from a JSON secret using `dataFrom`.
* See also: https://gitlab.com/ndrde/code/helm/external-secrets/-/blob/main/external-secrets/templates/external_secret.yaml
* docs: https://external-secrets.io/latest/guides/all-keys-one-secret/