### PR TITLE
[release] push charts to OCI registry after release

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.repository == 'subshell/helm-charts'}}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'subshell/helm-charts'}}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -42,6 +42,7 @@ jobs:
             oci_password: ${{ secrets.GITHUB_TOKEN }}
             github_token: ${{ secrets.GITHUB_TOKEN }}
             version: 'v4.2.2' # of helm
+            tag_name_pattern: 'helm/{chartName}'
             skip_gh_release: true
             skip_helm_install: true
         env:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -66,7 +66,13 @@ jobs:
             PAGE=$((PAGE + 1))
           done
           # download release assets
+          REMAINING=( "sophora-server-2.9.1.tgz sophora-server-3.0.0.tgz sophora-server-3.0.1.tgz sophora-server-3.1.0.tgz sophora-server-3.1.1.tgz sophora-server-3.1.2.tgz sophora-server-3.2.0.tgz sophora-server-3.3.0.tgz sophora-server-3.4.0.tgz sophora-tablestar-controller-1.0.0.tgz sophora-tablestar-controller-1.0.1.tgz sophora-tablestar-controller-1.0.2.tgz sophora-tablestar-controller-1.1.0.tgz sophora-ugc-1.0.0.tgz sophora-ugc-1.0.1.tgz sophora-ugc-1.0.2.tgz sophora-ugc-1.0.3.tgz sophora-ugc-2.0.0.tgz sophora-ugc-2.0.1.tgz sophora-ugc-2.0.10.tgz sophora-ugc-2.0.11.tgz sophora-ugc-2.0.12.tgz sophora-ugc-2.0.13.tgz sophora-ugc-2.0.14.tgz sophora-ugc-2.0.15.tgz sophora-ugc-2.0.2.tgz sophora-ugc-2.0.3.tgz sophora-ugc-2.0.4.tgz sophora-ugc-2.0.5.tgz sophora-ugc-2.0.6.tgz sophora-ugc-2.0.7.tgz sophora-ugc-2.0.8.tgz sophora-ugc-2.0.9.tgz sophora-ugc-2.1.0.tgz sophora-ugc-2.2.0.tgz sophora-ugc-2.2.1.tgz sophora-ugc-2.3.0.tgz sophora-ugc-2.4.0.tgz sophora-ugc-proxy-1.0.0.tgz sophora-ugc-proxy-1.0.1.tgz sophora-ugc-proxy-1.0.2.tgz sophora-ugc-proxy-1.1.0.tgz sophora-webclient-1.0.0.tgz sophora-webclient-1.0.1.tgz sophora-webclient-1.1.0.tgz sophora-webclient-1.2.0.tgz sophora-webclient-1.2.1.tgz sophora-webclient-1.2.2.tgz sophora-webclient-1.3.0.tgz sophora-webclient-1.4.0.tgz sophora-webclient-1.4.2.tgz sophora-webclient-1.4.3.tgz sophora-webclient-1.4.4.tgz sophora-webclient-1.4.5.tgz sophora-webclient-1.5.0.tgz sophora-webclient-1.5.1.tgz sophora-webclient-1.6.0.tgz sophora-youtube-connector-1.0.0.tgz sophora-youtube-connector-1.1.0.tgz sophora-youtube-connector-1.2.0.tgz sophora-youtube-connector-1.2.1.tgz sophora-youtube-connector-1.2.3.tgz sophora-youtube-connector-1.2.4.tgz sophora-youtube-connector-1.3.0.tgz sophora-youtube-connector-1.4.0.tgz sophora-youtube-connector-1.5.0.tgz youtube-connector-1.0.0.tgz" )
           for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do
+            FILENAME="${chartUrl##*/}"
+            if [[ ! " ${REMAINING[*]} " =~ " ${FILENAME} " ]]; then
+              echo "skipping $FILENAME (not in remaining list)"
+              continue
+            fi
             echo "downloading $chartUrl"
             curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --output-dir .cr-release-packages --remote-header-name -O
           done

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -71,7 +71,7 @@ jobs:
             COUNT=$(jq 'length' "$OUTPUT_FILE")
             echo "Page ${PAGE} has ${COUNT} releases"
             # note: 'grep -oP' uses Perl-compatible regex, '(?<=<)' Lookbehind '<', '[\S]*' Match zero or more non-whitespace characters, '(?=>; rel="next")' Lookahead: must be followed by '>; rel="next"'
-            RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next")')
+            RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next" || true)')
 
             if [ -z "$RELEASES_URL" ]; then
               echo "no next page, stopping"

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -36,21 +36,6 @@ jobs:
       #  env:
       #    CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       # TODO step will be removed before merge
-      - name: Fake release
-        run: |
-          mkdir -p .cr-release-packages
-          helm package charts/sophora-indexing-service --dependency-update --destination .cr-release-packages --debug
-
-      - name: Push charts to OCI registry
-        if: ${{ hashFiles('.cr-release-packages/*.tgz') != '' }}
-        run: |
-          echo "${MY_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-          for chart in .cr-release-packages/*.tgz; do
-            echo "pushing ${chart} to OCI registry"
-            helm push "$chart" oci://ghcr.io/subshell/helm-charts
-          done
-        env:
-          MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Download previous chart releases
         run: |
@@ -88,5 +73,16 @@ jobs:
           RELEASE_PACKAGES=( $(ls .cr-release-packages/) )
           echo "found ${#RELEASE_PACKAGES[@]} files:"
           echo "${RELEASE_PACKAGES[*]}"
+        env:
+          MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Push charts to OCI registry
+        if: ${{ hashFiles('.cr-release-packages/*.tgz') != '' }}
+        run: |
+          echo "${MY_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+          for chart in .cr-release-packages/*.tgz; do
+            echo "pushing ${chart} to OCI registry"
+            helm push "$chart" oci://ghcr.io/subshell/helm-charts
+          done
         env:
           MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           mkdir -p .cr-release-packages && cd .cr-release-packages
           # list artifacts of repository
-          PER_PAGE=30
+          PER_PAGE=25
           PAGE=1
           ARTIFACTS_URL="https://api.github.com/repos/subshell/helm-charts/actions/artifacts"
           CUTOFF_DATE="2025-01-01"
@@ -71,7 +71,7 @@ jobs:
             echo
             cat "${OUTPUT_FILE}"
             
-            COUNT=$(jq -r '.total_count' "$OUTPUT_FILE")
+            COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
             
             if [ "$COUNT" -lt "$PER_PAGE" ]; then

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -71,7 +71,7 @@ jobs:
             COUNT=$(jq 'length' "$OUTPUT_FILE")
             echo "Page ${PAGE} has ${COUNT} releases"
             # note: 'grep -oP' uses Perl-compatible regex, '(?<=<)' Lookbehind '<', '[\S]*' Match zero or more non-whitespace characters, '(?=>; rel="next")' Lookahead: must be followed by '>; rel="next"'
-            RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next" || true)')
+            RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next")' || true)
 
             if [ -z "$RELEASES_URL" ]; then
               echo "no next page, stopping"

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -58,26 +58,23 @@ jobs:
           # list releases and download assets
           PER_PAGE=50
           PAGE=1
-          RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases"
+          RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases?per_page=${PER_PAGE}&page=${PAGE}"
           CUTOFF_DATE="2025-01-01"
 
           while true; do
             OUTPUT_FILE="releases_page_${PAGE}.json"
             HEADERS_FILE="headers_${PAGE}.txt"
             
-            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${RELEASES_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
-            # TODO remove debug
-            cat "${HEADERS_FILE}"
-            echo
-            cat "${OUTPUT_FILE}"
+            echo "getting page with relases ${RELEASES_URL}"
+            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${RELEASES_URL}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
             
             COUNT=$(jq 'length' "$OUTPUT_FILE")
-            echo "Page ${PAGE}: ${COUNT} releases in ${OUTPUT_FILE}"
+            echo "Page ${PAGE} has ${COUNT} releases"
             # note: 'grep -oP' uses Perl-compatible regex, '(?<=<)' Lookbehind '<', '[\S]*' Match zero or more non-whitespace characters, '(?=>; rel="next")' Lookahead: must be followed by '>; rel="next"'
-            NEXT_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next"))
-            echo "next page URL is ${NEXT_URL}"
-            
-            if [ "$COUNT" -lt "$PER_PAGE" ]; then
+            RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next")')
+
+            if [ -z "$NEXT_URL" ]; then
+              echo "no next page, stopping"
               break
             fi
             # check date of last entry
@@ -87,7 +84,6 @@ jobs:
               break
             fi
             
-            PAGE=$((PAGE + 1))
           done
           # download release assets
           for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -51,3 +51,41 @@ jobs:
           done
         env:
           MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Download previous chart releases
+        run: |
+          mkdir -p .cr-release-packages && cd .cr-release-packages
+          # list artifacts of repository
+          PER_PAGE=30
+          PAGE=1
+          ARTIFACTS_URL="https://api.github.com/repos/subshell/helm-charts/actions/artifacts"
+          CUTOFF_DATE="2025-01-01"
+
+          while true; do
+            OUTPUT_FILE="artifacts_page_${PAGE}.json"
+            
+            curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}"
+            
+            COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
+            echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
+            
+            if [ "$COUNT" -lt "$PER_PAGE" ]; then
+              break
+            fi
+            # check date of last entry
+            LAST_UPDATED=$(jq -r '.artifacts[-1].updated_at' "${OUTPUT_FILE}")
+            if [[ "$LAST_UPDATED" < "$CUTOFF_DATE" ]]; then
+              echo "stopping because we got old artifacts updated $LAST_UPDATED"
+              break
+            fi
+            
+            PAGE=$((PAGE + 1))
+          done
+          for chartUrl in $(jq -r '.artifacts[].archive_download_url' artifacts_page_*.json); do
+            # download artifact
+            curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" -O
+          done
+          echo "downloaded: "; ls
+          cd -
+        env:
+          MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -74,10 +74,6 @@ jobs:
             COUNT=$(jq -r '.total_count' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
             
-            # note: 'grep -oP' uses Perl-compatible regex, '<\K' match < but exclude it from the result, '[^>]+' capture everything up to the closing >, '(?=>; rel="next")' lookahead to ensure it's followed by `; rel="next"`
-            NEXT_URL=$(grep "link:" "${HEADERS_FILE}" | grep -oP '<\K[^>]+(?=>; rel="next")')
-            echo "next url: $NEXT_URL"
-            
             if [ "$COUNT" -lt "$PER_PAGE" ]; then
               break
             fi

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -56,9 +56,9 @@ jobs:
         run: |
           mkdir -p .cr-release-packages
           # list releases and download assets
-          PER_PAGE=50
+          PER_PAGE=100
           PAGE=1
-          RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases?per_page=${PER_PAGE}&page=${PAGE}"
+          RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases?per_page=${PER_PAGE}"
           CUTOFF_DATE="2025-01-01"
 
           while true; do
@@ -79,13 +79,8 @@ jobs:
               cat "${HEADERS_FILE}"
               break
             fi
-            # check date of last entry
-            CREATED_AT=$(jq -r '.[-1].created_at' "${OUTPUT_FILE}")
-            if [[ "$CREATED_AT" < "$CUTOFF_DATE" ]]; then
-              echo "stopping because we got old release created $CREATED_AT"
-              break
-            fi
             
+            PAGE=$((PAGE + 1))
           done
           # download release assets
           for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Push charts to OCI registry
         if: ${{ hashFiles('.cr-release-packages/*.tgz') != '' }}
         run: |
-          echo "${MY_TOKEN}" | helm registry login ghcr.io/subshell --username subshell --password-stdin
+          echo "${MY_TOKEN}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
           for chart in .cr-release-packages/*.tgz; do
             echo "pushing ${chart} to OCI registry"
             helm push "$chart" oci://ghcr.io/subshell/helm-charts

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -34,16 +34,15 @@ jobs:
       #  uses: helm/chart-releaser-action@v1.7.0
       #  env:
       #    CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Run OCI charts releaser
-        uses: bitdeps/helm-oci-charts-releaser@v0.1.5
-        with:
-            oci_registry: ghcr.io/subshell
-            oci_username: subshell
-            oci_password: ${{ secrets.GITHUB_TOKEN }}
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            version: 'v4.2.2' # of helm
-            tag_name_pattern: 'helm/{chartName}'
-            skip_gh_release: true
-            skip_helm_install: true
-        env:
-          DRY_RUN: true
+      - name: Fake release
+        run: |
+          mkdir -p .cr-release-packages
+          touch .cr-release-packages/foo-1.2.3.tgz
+
+      - name: Push charts to OCI registry
+        if: ${{ hashFiles('.cr-release-packages/*.tgz') != '' }}
+        run: |
+          helm registry login ghcr.io/subshell --username subshell --password ${{ secrets.GITHUB_TOKEN }}
+          for chart in .cr-release-packages/*.tgz; do
+            helm push "$chart" oci://ghcr.io/subshell/helm
+          done

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,14 +1,14 @@
 name: Release Charts
 
 on:
-  - workflow_dispatch
-  - workflow_run:
-      workflows:
-        - Test Charts
-      branches:
-        - main
-      types:
-        - completed
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - Test Charts
+    branches:
+      - main
+    types:
+      - completed
 
 jobs:
   release:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -5,7 +5,8 @@ on:
     workflows:
       - Test Charts
     branches:
-      - main
+      # FIXME reset to main
+      - SUDO-610_oci_helmcharts
     types:
       - completed
 
@@ -26,10 +27,10 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
-        env:
-          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      #- name: Run chart-releaser
+      #  uses: helm/chart-releaser-action@v1.7.0
+      #  env:
+      #    CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
       - name: Run OCI charts releaser
         uses: bitdeps/helm-oci-charts-releaser@v0.1.5
         with:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Download previous chart releases
         run: |
-          mkdir -p .cr-release-packages && cd .cr-release-packages
+          mkdir -p .cr-release-packages
           # list releases and download assets
           PER_PAGE=30
           PAGE=1
@@ -89,9 +89,8 @@ jobs:
           # download release assets
           for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do
             echo "downloading $chartUrl"
-            curl --fail --no-progress-meter --skip-existing -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --remote-header-name -O
+            curl --fail --no-progress-meter --skip-existing -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --output-dir .cr-release-packages --remote-header-name -O
           done
-          echo "downloaded: "; ls -lh
-          cd -
+          echo "downloaded: "; ls -lh .cr-release-packages/
         env:
           MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -13,6 +13,9 @@ jobs:
   release:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'subshell/helm-charts'}}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,10 +26,19 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Helm Deps
-        run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Run OCI charts releaser
+        uses: bitdeps/helm-oci-charts-releaser@v0.1.5
+        with:
+            oci_registry: ghcr.io/subshell
+            oci_username: subshell
+            oci_password: ${{ secrets.GITHUB_TOKEN }}
+            github_token: ${{ secrets.GITHUB_TOKEN }}
+            version: 'v4.2.2' # of helm
+            skip_gh_release: true
+            skip_helm_install: true
+        env:
+          DRY_RUN: true

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,7 +1,7 @@
 name: Release Charts
 
 on:
-  workflow_dispatch:
+  # TODO push will be removed before merge
   push:
     branches:
       - SUDO-610_oci_helmcharts
@@ -30,10 +30,12 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      # TODO step will be uncommented before merge
       #- name: Run chart-releaser
       #  uses: helm/chart-releaser-action@v1.7.0
       #  env:
       #    CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      # TODO step will be removed before merge
       - name: Fake release
         run: |
           mkdir -p .cr-release-packages

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,10 +1,6 @@
 name: Release Charts
 
 on:
-  # TODO push will be removed before merge
-  push:
-    branches:
-      - SUDO-610_oci_helmcharts
   workflow_run:
     workflows:
       - Test Charts
@@ -30,57 +26,11 @@ jobs:
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      # TODO step will be uncommented before merge
-      #- name: Run chart-releaser
-      #  uses: helm/chart-releaser-action@v1.7.0
-      #  env:
-      #    CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-      # TODO step will be removed before merge
 
-      - name: Download previous chart releases
-        run: |
-          mkdir -p .cr-release-packages
-          # list releases and download assets
-          PER_PAGE=100
-          PAGE=1
-          RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases?per_page=${PER_PAGE}"
-          CUTOFF_DATE="2025-01-01"
-
-          while true; do
-            OUTPUT_FILE="releases_page_${PAGE}.json"
-            HEADERS_FILE="headers_${PAGE}.txt"
-            
-            echo "getting page with relases ${RELEASES_URL}"
-            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${RELEASES_URL}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
-            
-            COUNT=$(jq 'length' "$OUTPUT_FILE")
-            echo "Page ${PAGE} has ${COUNT} releases"
-            # note: 'grep -oP' uses Perl-compatible regex, '(?<=<)' Lookbehind '<', '[\S]*' Match zero or more non-whitespace characters, '(?=>; rel="next")' Lookahead: must be followed by '>; rel="next"'
-            RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next")' || true)
-
-            if [ -z "$RELEASES_URL" ]; then
-              echo "no next page, stopping"
-              break
-            fi
-            
-            PAGE=$((PAGE + 1))
-          done
-          # download release assets
-          REMAINING=( "sophora-server-2.9.1.tgz sophora-server-3.0.0.tgz sophora-server-3.0.1.tgz sophora-server-3.1.0.tgz sophora-server-3.1.1.tgz sophora-server-3.1.2.tgz sophora-server-3.2.0.tgz sophora-server-3.3.0.tgz sophora-server-3.4.0.tgz sophora-tablestar-controller-1.0.0.tgz sophora-tablestar-controller-1.0.1.tgz sophora-tablestar-controller-1.0.2.tgz sophora-tablestar-controller-1.1.0.tgz sophora-ugc-1.0.0.tgz sophora-ugc-1.0.1.tgz sophora-ugc-1.0.2.tgz sophora-ugc-1.0.3.tgz sophora-ugc-2.0.0.tgz sophora-ugc-2.0.1.tgz sophora-ugc-2.0.10.tgz sophora-ugc-2.0.11.tgz sophora-ugc-2.0.12.tgz sophora-ugc-2.0.13.tgz sophora-ugc-2.0.14.tgz sophora-ugc-2.0.15.tgz sophora-ugc-2.0.2.tgz sophora-ugc-2.0.3.tgz sophora-ugc-2.0.4.tgz sophora-ugc-2.0.5.tgz sophora-ugc-2.0.6.tgz sophora-ugc-2.0.7.tgz sophora-ugc-2.0.8.tgz sophora-ugc-2.0.9.tgz sophora-ugc-2.1.0.tgz sophora-ugc-2.2.0.tgz sophora-ugc-2.2.1.tgz sophora-ugc-2.3.0.tgz sophora-ugc-2.4.0.tgz sophora-ugc-proxy-1.0.0.tgz sophora-ugc-proxy-1.0.1.tgz sophora-ugc-proxy-1.0.2.tgz sophora-ugc-proxy-1.1.0.tgz sophora-webclient-1.0.0.tgz sophora-webclient-1.0.1.tgz sophora-webclient-1.1.0.tgz sophora-webclient-1.2.0.tgz sophora-webclient-1.2.1.tgz sophora-webclient-1.2.2.tgz sophora-webclient-1.3.0.tgz sophora-webclient-1.4.0.tgz sophora-webclient-1.4.2.tgz sophora-webclient-1.4.3.tgz sophora-webclient-1.4.4.tgz sophora-webclient-1.4.5.tgz sophora-webclient-1.5.0.tgz sophora-webclient-1.5.1.tgz sophora-webclient-1.6.0.tgz sophora-youtube-connector-1.0.0.tgz sophora-youtube-connector-1.1.0.tgz sophora-youtube-connector-1.2.0.tgz sophora-youtube-connector-1.2.1.tgz sophora-youtube-connector-1.2.3.tgz sophora-youtube-connector-1.2.4.tgz sophora-youtube-connector-1.3.0.tgz sophora-youtube-connector-1.4.0.tgz sophora-youtube-connector-1.5.0.tgz youtube-connector-1.0.0.tgz" )
-          for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do
-            FILENAME="${chartUrl##*/}"
-            if [[ ! " ${REMAINING[*]} " =~ " ${FILENAME} " ]]; then
-              echo "skipping $FILENAME (not in remaining list)"
-              continue
-            fi
-            echo "downloading $chartUrl"
-            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --output-dir .cr-release-packages --remote-header-name -O
-          done
-          RELEASE_PACKAGES=( $(ls .cr-release-packages/) )
-          echo "found ${#RELEASE_PACKAGES[@]} files:"
-          echo "${RELEASE_PACKAGES[*]}"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.7.0
         env:
-          MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          CR_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Push charts to OCI registry
         if: ${{ hashFiles('.cr-release-packages/*.tgz') != '' }}

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -45,7 +45,7 @@ jobs:
           echo "${MY_TOKEN}" | helm registry login ghcr.io/subshell --username subshell --password-stdin
           for chart in .cr-release-packages/*.tgz; do
             echo "pushing ${chart} to OCI registry"
-            helm push "$chart" oci://ghcr.io/subshell/helm
+            helm push "$chart" oci://ghcr.io/subshell/helm-charts
           done
         env:
           MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -55,40 +55,40 @@ jobs:
       - name: Download previous chart releases
         run: |
           mkdir -p .cr-release-packages && cd .cr-release-packages
-          # list artifacts of repository
-          PER_PAGE=25
+          # list releases and download assets
+          PER_PAGE=30
           PAGE=1
-          ARTIFACTS_URL="https://api.github.com/repos/subshell/helm-charts/actions/artifacts"
+          RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases"
           CUTOFF_DATE="2025-01-01"
 
           while true; do
-            OUTPUT_FILE="artifacts_page_${PAGE}.json"
+            OUTPUT_FILE="releases_page_${PAGE}.json"
             HEADERS_FILE="headers_${PAGE}.txt"
             
-            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
+            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${RELEASES_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
             # TODO remove debug
             cat "${HEADERS_FILE}"
             echo
             cat "${OUTPUT_FILE}"
             
-            COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
-            echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
+            COUNT=$(jq 'length' "$OUTPUT_FILE")
+            echo "Page ${PAGE}: ${COUNT} releases in ${OUTPUT_FILE}"
             
             if [ "$COUNT" -lt "$PER_PAGE" ]; then
               break
             fi
             # check date of last entry
-            LAST_UPDATED=$(jq -r '.artifacts[-1].updated_at' "${OUTPUT_FILE}")
-            if [[ "$LAST_UPDATED" < "$CUTOFF_DATE" ]]; then
-              echo "stopping because we got old artifacts updated $LAST_UPDATED"
+            CREATED_AT=$(jq -r '.[-1].created_at' "${OUTPUT_FILE}")
+            if [[ "$CREATED_AT" < "$CUTOFF_DATE" ]]; then
+              echo "stopping because we got old release created $CREATED_AT"
               break
             fi
             
             PAGE=$((PAGE + 1))
           done
-          # download newest of each artifacts
-          for chartUrl in $(jq -r '.artifacts | group_by(.name)[] | first | .archive_download_url' artifacts_page_*.json); do
-            echo "downloading $(jq -r ".artifacts[] | select(.archive_download_url == \"${chartUrl}\") | .name" artifacts_page_*.json)"
+          # download release assets
+          for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do
+            echo "downloading $chartUrl"
             curl --fail --no-progress-meter --skip-existing -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --remote-header-name -O
           done
           echo "downloaded: "; ls -lh

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Fake release
         run: |
           mkdir -p .cr-release-packages
+          helm package charts/sophora-indexing-service --dependency-update --destination .cr-release-packages --debug
           touch .cr-release-packages/foo-1.2.3.tgz
 
       - name: Push charts to OCI registry

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -2,6 +2,9 @@ name: Release Charts
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - SUDO-610_oci_helmcharts
   workflow_run:
     workflows:
       - Test Charts

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -38,12 +38,14 @@ jobs:
         run: |
           mkdir -p .cr-release-packages
           helm package charts/sophora-indexing-service --dependency-update --destination .cr-release-packages --debug
-          touch .cr-release-packages/foo-1.2.3.tgz
 
       - name: Push charts to OCI registry
         if: ${{ hashFiles('.cr-release-packages/*.tgz') != '' }}
         run: |
-          helm registry login ghcr.io/subshell --username subshell --password ${{ secrets.GITHUB_TOKEN }}
+          echo "${MY_TOKEN}" | helm registry login ghcr.io/subshell --username subshell --password-stdin
           for chart in .cr-release-packages/*.tgz; do
+            echo "pushing ${chart} to OCI registry"
             helm push "$chart" oci://ghcr.io/subshell/helm
           done
+        env:
+          MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -22,7 +22,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           mkdir -p .cr-release-packages
           # list releases and download assets
-          PER_PAGE=30
+          PER_PAGE=50
           PAGE=1
           RELEASES_URL="https://api.github.com/repos/subshell/helm-charts/releases"
           CUTOFF_DATE="2025-01-01"
@@ -73,6 +73,9 @@ jobs:
             
             COUNT=$(jq 'length' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} releases in ${OUTPUT_FILE}"
+            # note: 'grep -oP' uses Perl-compatible regex, '(?<=<)' Lookbehind '<', '[\S]*' Match zero or more non-whitespace characters, '(?=>; rel="next")' Lookahead: must be followed by '>; rel="next"'
+            NEXT_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next"))
+            echo "next page URL is ${NEXT_URL}"
             
             if [ "$COUNT" -lt "$PER_PAGE" ]; then
               break
@@ -89,7 +92,7 @@ jobs:
           # download release assets
           for chartUrl in $(jq -r '.[].assets[].browser_download_url' releases_page_*.json); do
             echo "downloading $chartUrl"
-            curl --fail --no-progress-meter --skip-existing -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --output-dir .cr-release-packages --remote-header-name -O
+            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --output-dir .cr-release-packages --remote-header-name -O
           done
           echo "downloaded: "; ls -lh .cr-release-packages/
         env:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -73,8 +73,10 @@ jobs:
             # note: 'grep -oP' uses Perl-compatible regex, '(?<=<)' Lookbehind '<', '[\S]*' Match zero or more non-whitespace characters, '(?=>; rel="next")' Lookahead: must be followed by '>; rel="next"'
             RELEASES_URL=$(grep 'link:' "${HEADERS_FILE}" | grep -oP '(?<=<)[\S]*(?=>; rel="next")')
 
-            if [ -z "$NEXT_URL" ]; then
+            if [ -z "$RELEASES_URL" ]; then
               echo "no next page, stopping"
+              # TODO remove debug
+              cat "${HEADERS_FILE}"
               break
             fi
             # check date of last entry

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -67,9 +67,11 @@ jobs:
             
             curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
             # TODO remove debug
+            cat "${HEADERS_FILE}"
+            echo
             cat "${OUTPUT_FILE}"
             
-            COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
+            COUNT=$(jq -r '.total_count' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
             
             # note: 'grep -oP' uses Perl-compatible regex, '<\K' match < but exclude it from the result, '[^>]+' capture everything up to the closing >, '(?=>; rel="next")' lookahead to ensure it's followed by `; rel="next"`
@@ -88,8 +90,8 @@ jobs:
             
             PAGE=$((PAGE + 1))
           done
-          for chartUrl in $(jq -r '.artifacts[].archive_download_url' artifacts_page_*.json); do
-            # download artifact
+          # download newest of each artifacts
+          for chartUrl in $(jq -r '.artifacts | group_by(.name)[] | first | .archive_download_url' artifacts_page_*.json); do
             echo "downloading $(jq -r ".artifacts[] | select(.archive_download_url == \"${chartUrl}\") | .name" artifacts_page_*.json)"
             curl --fail --no-progress-meter --skip-existing -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --remote-header-name -O
           done

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -64,7 +64,7 @@ jobs:
           while true; do
             OUTPUT_FILE="artifacts_page_${PAGE}.json"
             
-            curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}"
+            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}"
             
             COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
@@ -83,9 +83,10 @@ jobs:
           done
           for chartUrl in $(jq -r '.artifacts[].archive_download_url' artifacts_page_*.json); do
             # download artifact
-            curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" -O
+            echo "downloading $(jq -r ".artifacts[] | select(.archive_download_url == \"${chartUrl}\") | .name" artifacts_page_*.json)"
+            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --remote-header-name -O
           done
-          echo "downloaded: "; ls
+          echo "downloaded: "; ls -lh
           cd -
         env:
           MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,14 +1,14 @@
 name: Release Charts
 
 on:
-  workflow_run:
-    workflows:
-      - Test Charts
-    branches:
-      # FIXME reset to main
-      - SUDO-610_oci_helmcharts
-    types:
-      - completed
+  - workflow_dispatch
+  - workflow_run:
+      workflows:
+        - Test Charts
+      branches:
+        - main
+      types:
+        - completed
 
 jobs:
   release:

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -63,13 +63,18 @@ jobs:
 
           while true; do
             OUTPUT_FILE="artifacts_page_${PAGE}.json"
+            HEADERS_FILE="headers_${PAGE}.txt"
             
-            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}"
+            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}" --dump-header "${HEADERS_FILE}"
             # TODO remove debug
             cat "${OUTPUT_FILE}"
             
             COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
+            
+            # note: 'grep -oP' uses Perl-compatible regex, '<\K' match < but exclude it from the result, '[^>]+' capture everything up to the closing >, '(?=>; rel="next")' lookahead to ensure it's followed by `; rel="next"`
+            NEXT_URL=$(grep "link:" "${HEADERS_FILE}" | grep -oP '<\K[^>]+(?=>; rel="next")')
+            echo "next url: $NEXT_URL"
             
             if [ "$COUNT" -lt "$PER_PAGE" ]; then
               break

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -65,6 +65,8 @@ jobs:
             OUTPUT_FILE="artifacts_page_${PAGE}.json"
             
             curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${ARTIFACTS_URL}?per_page=${PER_PAGE}&page=${PAGE}" -o "${OUTPUT_FILE}"
+            # TODO remove debug
+            cat "${OUTPUT_FILE}"
             
             COUNT=$(jq -r '.artifacts | length' "$OUTPUT_FILE")
             echo "Page ${PAGE}: ${COUNT} artifacts in ${OUTPUT_FILE}"
@@ -84,7 +86,7 @@ jobs:
           for chartUrl in $(jq -r '.artifacts[].archive_download_url' artifacts_page_*.json); do
             # download artifact
             echo "downloading $(jq -r ".artifacts[] | select(.archive_download_url == \"${chartUrl}\") | .name" artifacts_page_*.json)"
-            curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --remote-header-name -O
+            curl --fail --no-progress-meter --skip-existing -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --remote-header-name -O
           done
           echo "downloaded: "; ls -lh
           cd -

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == 'subshell/helm-charts'}}
+    if: ${{ github.repository == 'subshell/helm-charts'}}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -75,8 +75,6 @@ jobs:
 
             if [ -z "$RELEASES_URL" ]; then
               echo "no next page, stopping"
-              # TODO remove debug
-              cat "${HEADERS_FILE}"
               break
             fi
             
@@ -87,6 +85,8 @@ jobs:
             echo "downloading $chartUrl"
             curl --fail --no-progress-meter -L -H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${MY_TOKEN}" -H "X-GitHub-Api-Version: 2026-03-10" "${chartUrl}" --output-dir .cr-release-packages --remote-header-name -O
           done
-          echo "downloaded: "; ls -lh .cr-release-packages/
+          RELEASE_PACKAGES=( $(ls .cr-release-packages/) )
+          echo "found ${#RELEASE_PACKAGES[@]} files:"
+          echo "${RELEASE_PACKAGES[*]}"
         env:
           MY_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/README.md
+++ b/README.md
@@ -6,10 +6,33 @@ Helm charts supported by subshell.
 
 ## Add Repo
 
+The following sections describe how you access charts from this repository. They are available via HTTP or OCI.
+
+Both the HTTP repository and the OCI registry are kept in sync on every release.
+
+
+### HTTP repository
+
 The following command allows you to download and install all the charts from this repository:
 
 ```sh
 helm repo add subshell https://subshell.github.io/helm-charts
+```
+
+### OCI Registry
+
+Charts are also available via an [OCI-based registry](https://helm.sh/docs/topics/registries/). This is the preferred method if you want to cache or mirror artifacts locally, as OCI registries integrate natively with standard container registry tooling.
+
+To install a chart directly from the OCI registry:
+
+```sh
+helm install my-release oci://ghcr.io/subshell/helm-charts/<chart-name> --version <version>
+```
+
+To pull a chart without installing:
+
+```sh
+helm pull oci://ghcr.io/subshell/helm-charts/<chart-name> --version <version>
 ```
 
 ## Development
@@ -18,7 +41,7 @@ All charts should be located in the `charts` directory. On every push to the
 main branch, a release of the helm chart is triggered automatically if the
 `Chart.yaml` file contains a new version.
 
-This git repository uses [Github Pages](https://helm.sh/docs/topics/chart_repository/#github-pages-example) to host the helm repository.
+This git repository uses [Github Pages](https://helm.sh/docs/topics/chart_repository/#github-pages-example) to host the helm repository (for HTTP).
 
 ## Changelogs
 
@@ -36,4 +59,3 @@ annotations:
 * * *
 
 Take a look at this project from the [subshell](https://subshell.com) team. We make [Sophora](https://subshell.com/sophora/): a content management software for content creation, curation, and distribution. [Join our team!](https://subshell.com/jobs/) | [Imprint](https://subshell.com/about/imprint/)
-

--- a/charts/sophora-indexing-service/Chart.yaml
+++ b/charts/sophora-indexing-service/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-indexing-service
 description: Sophora Indexing Service (SISI)
 type: application
-version: 1.7.0
+version: 1.7.1
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Changed docker.subshell.com to container.subshell.com."
+      description: "Readme added valkey and solr-operator besides Bitnami"
 
 appVersion: '5.4.1'
 sources:

--- a/charts/sophora-indexing-service/README.md
+++ b/charts/sophora-indexing-service/README.md
@@ -7,8 +7,8 @@ The Sophora Indexing Service reads all Sophora documents and indexes them in Sol
 The software requires these dependencies (not necessarily by Bitnami though).
 They are not included as Chart dependencies, and they need to be installed separately.
 
-* [bitnami/redis](https://bitnami.com/stack/redis/helm)
-* [bitnami/solr](https://bitnami.com/stack/solr/helm)
+* Redis: [valkey/valkey](https://github.com/valkey-io/valkey-helm) or [bitnami/redis](https://github.com/bitnami/charts/tree/main/bitnami/redis)
+* SolrCloud: [apache-solr/solr](https://github.com/apache/solr-operator/tree/main/helm/solr) or [bitnami/solr](https://github.com/bitnami/charts/tree/main/bitnami/solr)
 
 ## Example
 


### PR DESCRIPTION
Pushes charts to subshells GitHub container registry as OCI artifacts.

see also https://support.subshell.com/browse/UNSO-3393