### PR TITLE
[sophora-importer] Remove downloadViaHttpImage

### DIFF
--- a/charts/sophora-importer/Chart.yaml
+++ b/charts/sophora-importer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.8.0
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed docker.subshell.com to container.subshell.com."
+    - kind: removed
+      description: "Remove downloadViaHttpImage"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-importer/scripts/download_zip.sh
+++ b/charts/sophora-importer/scripts/download_zip.sh
@@ -5,11 +5,3 @@ if [ -n "$S3_FILE_PATHS" ]; then
     echo "Downloaded $S3_FILE_PATH"
   done
 fi
-
-# download via http if the required env variables are set
-if [ -n "$REPO_ZIP_URLS" ]; then
-  for REPO_ZIP_URL in $REPO_ZIP_URLS; do
-    wget -q --user="${HTTP_USERNAME}" --password="${HTTP_PASSWORD}" "$REPO_ZIP_URL";
-    echo "Downloaded $REPO_ZIP_URL"
-  done
-fi

--- a/charts/sophora-importer/templates/statefulset.yaml
+++ b/charts/sophora-importer/templates/statefulset.yaml
@@ -145,7 +145,6 @@ spec:
       initContainers:
       {{/* Transformations Download */}}
       {{- with .Values.transformation }}
-      {{- if and .enabled (eq .data.use "s3") }}
       - name: transformation-data-via-s3-downloader
         image: "{{ $.Values.downloadViaS3Image.repository }}:{{ $.Values.downloadViaS3Image.tag }}"
         imagePullPolicy: {{ $.Values.downloadViaS3Image.pullPolicy }}
@@ -176,34 +175,6 @@ spec:
           - name: libs
             mountPath: {{ include "sophora-importer.transformationLibsPath" . }}
       {{- end }}
-      {{- if and .enabled (eq .data.use "http") }}
-      - name: transformation-data-via-http-downloader
-        image: "{{ $.Values.downloadViaS3Image.repository }}:{{ $.Values.downloadViaS3Image.tag }}"
-        imagePullPolicy: {{ $.Values.downloadViaS3Image.pullPolicy }}
-        env:
-          - name: REPO_ZIP_URLS
-            value: {{ include "sophora-importer.utils.joinListWithSpace" .data.zipViaHttp.zipUrls | quote }}
-          - name: HTTP_USERNAME
-            valueFrom:
-              secretKeyRef:
-                key: {{ .data.zipViaHttp.usernameKey | quote }}
-                name: {{ .data.zipViaHttp.secretName | quote }}
-          - name: HTTP_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                key: {{ .data.zipViaHttp.passwordKey }}
-                name: {{ .data.zipViaHttp.secretName | quote }}
-        command: ["/bin/sh"]
-        args:
-          - "-c"
-          - |- {{- include "sophora-importer.downloadTransformationsScript" $ | nindent 14 }}
-        volumeMounts:
-          - name: xsl
-            mountPath: {{ include "sophora-importer.transformationXslPath" . }}
-          - name: libs
-            mountPath: {{ include "sophora-importer.transformationLibsPath" . }}
-        {{- end }}
-        {{- end }}
       volumes:
       - name: importer-config
         configMap:

--- a/charts/sophora-importer/values.yaml
+++ b/charts/sophora-importer/values.yaml
@@ -4,11 +4,6 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master"
 
-downloadViaHttpImage:
-  repository: "container.subshell.com/misc/alpine-toolkit"
-  tag: "0.2.0"
-  pullPolicy: IfNotPresent
-
 downloadViaS3Image:
   repository: "container.subshell.com/misc/aws-cli-tools"
   tag: "0.0.2"
@@ -73,12 +68,6 @@ transformation:
   enabled: false
   xslTransformerFactory:
   data:
-    use: s3
-    zipViaHttp:
-      secretName:
-      zipUrls:
-      usernameKey: "username"
-      passwordKey: "password"
     zipViaS3:
       secretName:
       s3Endpoint: "https://storage.googleapis.com"


### PR DESCRIPTION
This has never worked, at least not since release 1.0.0. Image `docker.subshell.com/misc/aws-cli-tools` was to be used when `data.use` was set to `http`. But this image does not contain the needed binary `wget` which broke the whole functionality.

See https://support.subshell.com/browse/ZUPUS-972