### PR TITLE
[gateway] wildcard hostnames will use "wildcard" instead of "*" for the listener name

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -9,8 +9,8 @@ type: application
 version: 1.1.1
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "use gateway HTTPS listener name when set"
+    - kind: fixed
+      description: "wildcard hostnames no longer break the listener and certificate name"
 
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/gateway

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "add optional GCPGatewayPolicy resource for GKE"
+    - kind: changed
+      description: "use gateway HTTPS listener name when set"
 
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/gateway

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -37,7 +37,7 @@ gateway:
 
 ### Wildcard host
 
-For wildcard hosts the `name` field is required, because `*` is not a valid character in Kubernetes resource names.
+For wildcard hosts the `name` field is required, because `*` of the hostname is not a valid character in Kubernetes resource names.
 
 ```yaml
 gateway:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -35,6 +35,17 @@ gateway:
     - host: simple.example.com
 ```
 
+### Wildcard host
+
+For wildcard hosts the `name` field is required, because `*` is not a valid character in Kubernetes resource names.
+
+```yaml
+gateway:
+  https:
+    - host: "*.example.com"
+      name: wildcard-example-com
+```
+
 ### Basic with cert-manager certificate
 
 ```yaml
@@ -63,6 +74,8 @@ gateway:
     - value: 1.2.3.4
   https:
     - host: simple.example.com
+    - host: "*.example.com"
+      name: wildcard-example-com
     - host: chart-example.local
       allowedRoutes:
         namespaces:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -64,7 +64,6 @@ gateway:
   https:
     - host: simple.example.com
     - host: "*.example.com"
-      name: wildcard-example-com
     - host: chart-example.local
       allowedRoutes:
         namespaces:

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -23,7 +23,7 @@ Only when certificates should be provided by cert-manager with [annotated Gatewa
 
 ## Notes
 
-- When using a regional load balancer then the IP address must be regional too. When using a global load balancer use a global IP address.
+- Google Cloud: When using a regional load balancer then the IP address must be regional too. When using a global load balancer use a global IP address.
 
 ## Example values.yaml
 
@@ -33,17 +33,6 @@ Only when certificates should be provided by cert-manager with [annotated Gatewa
 gateway:
   https:
     - host: simple.example.com
-```
-
-### Wildcard host
-
-For wildcard hosts the `name` field is required, because `*` of the hostname is not a valid character in Kubernetes resource names.
-
-```yaml
-gateway:
-  https:
-    - host: "*.example.com"
-      name: wildcard-example-com
 ```
 
 ### Basic with cert-manager certificate

--- a/charts/gateway/templates/gateway.yaml
+++ b/charts/gateway/templates/gateway.yaml
@@ -32,7 +32,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- range .Values.gateway.https }}
-    - name: "https-{{ .host }}"
+    - name: "https-{{ default .host .name }}"
       hostname: "{{ .host }}"
       port: 443
       protocol: HTTPS
@@ -43,7 +43,7 @@ spec:
           - name: "{{ .tls.certRef }}"
       {{- else if or $certManager.clusterIssuer $certManager.issuer }}
         certificateRefs:
-          - name: "gw-cert-{{ .host }}"
+          - name: "gw-cert-{{ default .host .name }}"
       {{- end }}
       allowedRoutes:
       {{- if .allowedRoutes }}

--- a/charts/gateway/templates/gateway.yaml
+++ b/charts/gateway/templates/gateway.yaml
@@ -32,7 +32,11 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- range .Values.gateway.https }}
-    - name: "https-{{ default .host .name }}"
+    {{- if and (contains "*" .host) (not .name) }}
+      {{- fail (printf "gateway.https[].name is required when host contains a wildcard: %s" .host) }}
+    {{- end }}
+    {{- $effectiveName := default .host .name }}
+    - name: "https-{{ $effectiveName }}"
       hostname: "{{ .host }}"
       port: 443
       protocol: HTTPS
@@ -43,7 +47,7 @@ spec:
           - name: "{{ .tls.certRef }}"
       {{- else if or $certManager.clusterIssuer $certManager.issuer }}
         certificateRefs:
-          - name: "gw-cert-{{ default .host .name }}"
+          - name: "gw-cert-{{ $effectiveName }}"
       {{- end }}
       allowedRoutes:
       {{- if .allowedRoutes }}

--- a/charts/gateway/templates/gateway.yaml
+++ b/charts/gateway/templates/gateway.yaml
@@ -32,10 +32,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- range .Values.gateway.https }}
-    {{- if and (contains "*" .host) (not .name) }}
-      {{- fail (printf "gateway.https[].name is required when host contains a wildcard: %s" .host) }}
-    {{- end }}
-    {{- $effectiveName := default .host .name }}
+    {{- $effectiveName := .host | replace "*" "wildcard" }}
     - name: "https-{{ $effectiveName }}"
       hostname: "{{ .host }}"
       port: 443

--- a/charts/gateway/tests/gateway_test.yaml
+++ b/charts/gateway/tests/gateway_test.yaml
@@ -127,6 +127,17 @@ tests:
                   selector:
                     matchLabels:
                       example: use-gateway
+              - name: "https-wildcard-example.com"
+                hostname: "*.example.com"
+                port: 443
+                protocol: HTTPS
+                tls:
+                  mode: Terminate
+                  certificateRefs:
+                    - name: "gw-cert-wildcard-example.com"
+                allowedRoutes:
+                  namespaces:
+                    from: All
             infrastructure:
               annotations:
                 foo: bar

--- a/charts/gateway/tests/gateway_test.yaml
+++ b/charts/gateway/tests/gateway_test.yaml
@@ -127,14 +127,14 @@ tests:
                   selector:
                     matchLabels:
                       example: use-gateway
-              - name: "https-wildcard-example.com"
+              - name: "https-wildcard.example.com"
                 hostname: "*.example.com"
                 port: 443
                 protocol: HTTPS
                 tls:
                   mode: Terminate
                   certificateRefs:
-                    - name: "gw-cert-wildcard-example.com"
+                    - name: "gw-cert-wildcard.example.com"
                 allowedRoutes:
                   namespaces:
                     from: All

--- a/charts/gateway/tests/values/full.yaml
+++ b/charts/gateway/tests/values/full.yaml
@@ -25,6 +25,8 @@ gateway:
     tls:
       mode: Passthrough
       certRef: chart-example-tls
+  - host: "*.example.com"
+    name: wildcard-example.com
   listeners:
   - name: other-port
     hostname: other.example.com

--- a/charts/gateway/tests/values/full.yaml
+++ b/charts/gateway/tests/values/full.yaml
@@ -26,7 +26,6 @@ gateway:
       mode: Passthrough
       certRef: chart-example-tls
   - host: "*.example.com"
-    name: wildcard-example.com
   listeners:
   - name: other-port
     hostname: other.example.com

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -17,8 +17,6 @@ gateway:
   # HTTPS hosts listening on default port 443
   https: []
 #    - host: chart-example.local
-#      # Optional: override the listener and certificate name. Required for wildcard hosts (e.g. *.example.com).
-#      # name: chart-example-local
 #      allowedRoutes:
 #        namespaces:
 #          from: Same

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -17,6 +17,8 @@ gateway:
   # HTTPS hosts listening on default port 443
   https: []
 #    - host: chart-example.local
+#      # Optional: override the listener and certificate name. Required for wildcard hosts (e.g. *.example.com).
+#      # name: chart-example-local
 #      allowedRoutes:
 #        namespaces:
 #          from: Same


### PR DESCRIPTION
[TSTCLD-108](https://support.subshell.com/browse/TSTCLD-108)