### PR TITLE
[planr-tools] fix missing 'end' in gcpHealthCheck template

### DIFF
--- a/charts/planr-tools/Chart.yaml
+++ b/charts/planr-tools/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: planr-tools
 description: A Helm chart for deploying the planr-tools applications
 type: application
-version: 1.3.0
+version: 1.3.1
 appVersion: "5.1.1"
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "HTTPRoute configuration changed to a map of routes via httpRoutes{}. The previous httpRoute field has been removed (breaking change)!"
+    - kind: fixed
+      description: "Fixed a missing 'end' in the gcpHealthCheck template that prevented the whole chart from rendering"
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/planr-tools
 home: https://gitlab.com/subshell/kunden/planr-tools

--- a/charts/planr-tools/templates/gcpHealthCheck.yaml
+++ b/charts/planr-tools/templates/gcpHealthCheck.yaml
@@ -31,3 +31,4 @@ spec:
     name: {{ $fullName }}
 {{- end }}
 {{- end }}
+{{- end }}

--- a/charts/planr-tools/tests/gcphealthcheck_test.yaml
+++ b/charts/planr-tools/tests/gcphealthcheck_test.yaml
@@ -1,0 +1,56 @@
+suite: test gcp health check
+templates:
+  - gcpHealthCheck.yaml
+chart:
+  version: 1.0.0
+  appVersion: 5.1.1
+tests:
+  - it: should not create health check policies by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create a health check policy for every enabled application
+    release:
+      name: values-test-release
+    set:
+      gcp.healthCheck.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 3
+      - containsDocument:
+          kind: HealthCheckPolicy
+          apiVersion: networking.gke.io/v1
+          name: values-test-release-planr-tools-newsroom-document-creator
+          any: true
+      - containsDocument:
+          kind: HealthCheckPolicy
+          apiVersion: networking.gke.io/v1
+          name: values-test-release-planr-tools-newsroom-feed
+          any: true
+      - containsDocument:
+          kind: HealthCheckPolicy
+          apiVersion: networking.gke.io/v1
+          name: values-test-release-planr-tools-newsroom-widget
+          any: true
+      - equal:
+          path: spec.default.config.healthCheck.portName
+          value: http
+      - equal:
+          path: spec.default.config.healthCheck.requestPath
+          value: /actuator/health/readiness
+      - equal:
+          path: spec.targetRef.kind
+          value: Service
+      - notFailedTemplate: {}
+
+  - it: should not create a health check policy for disabled applications
+    release:
+      name: values-test-release
+    set:
+      gcp.healthCheck.enabled: true
+      applications.feed.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - notFailedTemplate: {}


### PR DESCRIPTION
## Problem

`charts/planr-tools/templates/gcpHealthCheck.yaml` opens three template blocks (`if` → `range` → `if`) but only closes two of them, so Helm fails with:

```
Error: parse error at (planr-tools/templates/gcpHealthCheck.yaml:34): unexpected EOF
```

Because Go template syntax errors surface at parse time (before values are evaluated), this breaks the entire chart for every values combination — `helm install`, `upgrade`, `template` and `lint` all fail, even with the default `gcp.healthCheck.enabled: false`.

The template was introduced in #289. The sibling charts got a correct copy; only the planr-tools variant, which additionally loops over `applications`, is missing one `{{- end }}`.

Possibly useful observation from investigating this: the `planr-tools-1.3.0` GitHub release/tag exists (created during the failed "Release Charts" run on July 3), but 1.3.0 never made it into the HTTP index or the OCI registry — the latest installable version is still 1.2.0.

## Fix

- Add the missing `{{- end }}` for the outer `if`.
- Bump the chart version to **1.3.1** — the `planr-tools-1.3.0` tag already exists, so chart-releaser would skip a re-release of 1.3.0 — and update the changelog annotation.
- Add unit tests for `gcpHealthCheck.yaml`. helm-unittest only parses templates referenced by a test suite, which is why CI stayed green; with these tests the template is now covered.

## Verification

- `helm lint` passes (previously: parse error)
- `helm template` with defaults renders again; with `gcp.healthCheck.enabled=true` it produces one `HealthCheckPolicy` per enabled application and none for disabled ones
- `helm unittest` with helm v3.20.0 (same version as the Test Charts workflow): **17/17 tests pass** (14 existing + 3 new)

If you're interested, I'd be happy to add a `helm lint` step to the test workflow in a follow-up PR — it would catch this class of error for all charts.

**Note:** while verifying I also noticed that the `HealthCheckPolicy` structure produced by the `gcpHealthCheck` templates doesn't seem to match the current `networking.gke.io/v1` CRD schema (`config.healthCheck` vs. `config.httpHealthCheck`, `logConfig` placement). That affects all charts shipping this template, so rather than widening this PR I'll research it properly and file a separate issue.
