### PR TITLE
[sophora-cluster-common, sophora-server] add full grpc gateway support

### DIFF
--- a/charts/sophora-cluster-common/Chart.yaml
+++ b/charts/sophora-cluster-common/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-cluster-common
 description: A Helm chart containing some common resources useful for Sophora cloud setups
 type: application
-version: 1.6.2
+version: 1.7.0
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: added
+      description: "Added support for GRPCRoute and gRPC-HTTPRoute resources to the Sophora cluster common chart"
 
 appVersion: "4"
 sources:

--- a/charts/sophora-cluster-common/Chart.yaml
+++ b/charts/sophora-cluster-common/Chart.yaml
@@ -6,7 +6,7 @@ version: 1.7.0
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Added support for GRPCRoute and gRPC-HTTPRoute resources to the Sophora cluster common chart"
+      description: "Added support for GRPCRoute, gRPC HTTPRoute, and GCP gRPC HealthCheckPolicy resources"
 
 appVersion: "4"
 sources:

--- a/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterServerLb.enabled .Values.gcp.grpcHealthCheck.enabled }}
+{{- if and .Values.clusterServerLb.enabled .Values.gcp.grpcHealthCheck.enabled (or .Values.clusterServerLb.grpcIngress.enabled .Values.clusterServerLb.grpcRoute.enabled .Values.clusterServerLb.grpcHttproute.enabled) }}
 ---
 {{- $fullName := include "sophora-cluster-common.fullname" . -}}
 {{- $labels := include "sophora-cluster-common.labels" . -}}

--- a/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.clusterServerLb.enabled .Values.gcp.grpcHealthCheck.enabled }}
+---
+{{- $fullName := include "sophora-cluster-common.fullname" . -}}
+{{- $labels := include "sophora-cluster-common.labels" . -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        port: {{ .Values.clusterServerLb.service.grpcPort }}
+    logConfig:
+      enabled: {{ .Values.gcp.grpcHealthCheck.logging }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ .Values.clusterServerLb.name }}
+{{- end }}

--- a/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
@@ -5,7 +5,7 @@
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:
-  name: {{ $fullName }}
+  name: {{ printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
   labels:
     {{- $labels | nindent 4 }}
 spec:

--- a/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-cluster-common/templates/lb/gcpGRPCHealthCheck.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterServerLb.enabled .Values.gcp.grpcHealthCheck.enabled (or .Values.clusterServerLb.grpcIngress.enabled .Values.clusterServerLb.grpcRoute.enabled .Values.clusterServerLb.grpcHttproute.enabled) }}
+{{- if and .Values.clusterServerLb.enabled .Values.gcp.grpcHealthCheck.enabled (or .Values.clusterServerLb.grpcIngress.enabled .Values.clusterServerLb.grpcRoutes .Values.clusterServerLb.grpcHttproutes) }}
 ---
 {{- $fullName := include "sophora-cluster-common.fullname" . -}}
 {{- $labels := include "sophora-cluster-common.labels" . -}}

--- a/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterServerLb.grpcHttproute.enabled -}}
+{{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.grpcHttproute.enabled -}}
   {{- $fullName := include "sophora-cluster-common.fullname" . -}}
   {{- $labels := include "sophora-cluster-common.labels" . -}}
   {{- $routeName := printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
@@ -7,7 +7,7 @@ kind: HTTPRoute
 metadata:
   name: {{ $routeName }}
   labels:
-    {{ $labels | nindent 4 }}
+  {{- $labels | nindent 4 }}
   {{- with .Values.clusterServerLb.grpcHttproute.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -25,7 +25,7 @@ spec:
   {{- end }}
   rules:
     - backendRefs:
-        - name: {{ $fullName }}
+        - name: {{ .Values.clusterServerLb.name }}
           port: {{ .Values.clusterServerLb.service.grpcPort }}
       {{- with .Values.clusterServerLb.grpcHttproute.matches }}
       matches:

--- a/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
@@ -1,38 +1,42 @@
 {{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.grpcHttproute.enabled -}}
-  {{- $fullName := include "sophora-cluster-common.fullname" . -}}
-  {{- $labels := include "sophora-cluster-common.labels" . -}}
-  {{- $routeName := printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
+{{- $fullName := include "sophora-cluster-common.fullname" . -}}
+{{- $labels := include "sophora-cluster-common.labels" . -}}
+{{- $svcPort := .Values.clusterServerLb.service.grpcPort -}}
+{{- range $nameSuffix := (.Values.clusterServerLb.grpcHttproutes | keys | sortAlpha) }}
+{{- $httpRoute := index $.Values.clusterServerLb.grpcHttproutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $routeName }}
+  name: {{ printf "%s-%s" $fullName $nameSuffix | trunc 63 | trimSuffix "-" }}
   labels:
-  {{- $labels | nindent 4 }}
-  {{- with .Values.clusterServerLb.grpcHttproute.annotations }}
+    {{- $labels | nindent 4 }}
+  {{- with $httpRoute.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.clusterServerLb.grpcHttproute.parentRefs }}
+  {{- with $httpRoute.parentRefs }}
   parentRefs:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.clusterServerLb.grpcHttproute.hostnames }}
+  {{- if $httpRoute.hostnames }}
   hostnames:
-  {{- range .Values.clusterServerLb.grpcHttproute.hostnames }}
+  {{- range $httpRoute.hostnames }}
     - {{ . | quote }}
   {{- end }}
   {{- end }}
   rules:
     - backendRefs:
-        - name: {{ .Values.clusterServerLb.name }}
-          port: {{ .Values.clusterServerLb.service.grpcPort }}
-      {{- with .Values.clusterServerLb.grpcHttproute.matches }}
+        - name: {{ $.Values.clusterServerLb.name }}
+          port: {{ $svcPort }}
+      {{- with $httpRoute.matches }}
       matches:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.clusterServerLb.grpcHttproute.filters }}
+      {{- with $httpRoute.filters }}
       filters:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.clusterServerLb.grpcHttproute.enabled -}}
+  {{- $fullName := include "sophora-cluster-common.fullname" . -}}
+  {{- $labels := include "sophora-cluster-common.labels" . -}}
+  {{- $routeName := printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $routeName }}
+  labels:
+    {{ $labels | nindent 4 }}
+  {{- with .Values.clusterServerLb.grpcHttproute.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.clusterServerLb.grpcHttproute.parentRefs }}
+  parentRefs:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.clusterServerLb.grpcHttproute.hostnames }}
+  hostnames:
+  {{- range .Values.clusterServerLb.grpcHttproute.hostnames }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.clusterServerLb.service.grpcPort }}
+      {{- with .Values.clusterServerLb.grpcHttproute.matches }}
+      matches:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterServerLb.grpcHttproute.filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpc-httproute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.grpcHttproute.enabled -}}
+{{- if .Values.clusterServerLb.enabled -}}
 {{- $fullName := include "sophora-cluster-common.fullname" . -}}
 {{- $labels := include "sophora-cluster-common.labels" . -}}
 {{- $svcPort := .Values.clusterServerLb.service.grpcPort -}}

--- a/charts/sophora-cluster-common/templates/lb/grpcRoute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpcRoute.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.clusterServerLb.grpcRoute.enabled -}}
+  {{- $fullName := include "sophora-cluster-common.fullname" . -}}
+  {{- $labels := include "sophora-cluster-common.labels" . -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: {{ $fullName }}
+  labels:
+  {{ $labels | nindent 4 }}
+  {{- with .Values.clusterServerLb.grpcRoute.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.clusterServerLb.grpcRoute.parentRefs }}
+  parentRefs:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.clusterServerLb.grpcRoute.hostnames }}
+  hostnames:
+  {{- range .Values.clusterServerLb.grpcRoute.hostnames }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ .Values.clusterServerLb.service.grpcPort }}
+      {{- with .Values.clusterServerLb.grpcRoute.matches }}
+      matches:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.clusterServerLb.grpcRoute.filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/sophora-cluster-common/templates/lb/grpcRoute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpcRoute.yaml
@@ -1,37 +1,42 @@
-{{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.grpcRoute.enabled -}}
-  {{- $fullName := include "sophora-cluster-common.fullname" . -}}
-  {{- $labels := include "sophora-cluster-common.labels" . -}}
+{{- if .Values.clusterServerLb.enabled -}}
+{{- $fullName := include "sophora-cluster-common.fullname" . -}}
+{{- $labels := include "sophora-cluster-common.labels" . -}}
+{{- $svcPort := .Values.clusterServerLb.service.grpcPort -}}
+{{- range $nameSuffix := (.Values.clusterServerLb.grpcRoutes | keys | sortAlpha) }}
+{{- $httpRoute := index $.Values.clusterServerLb.grpcRoutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
-  name: {{ $fullName }}
+  name: {{ printf "%s-%s" $fullName $nameSuffix | trunc 63 | trimSuffix "-" }}
   labels:
-  {{- $labels | nindent 4 }}
-  {{- with .Values.clusterServerLb.grpcRoute.annotations }}
+    {{- $labels | nindent 4 }}
+  {{- with $httpRoute.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.clusterServerLb.grpcRoute.parentRefs }}
+  {{- with $httpRoute.parentRefs }}
   parentRefs:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.clusterServerLb.grpcRoute.hostnames }}
+  {{- if $httpRoute.hostnames }}
   hostnames:
-  {{- range .Values.clusterServerLb.grpcRoute.hostnames }}
+  {{- range $httpRoute.hostnames }}
     - {{ . | quote }}
   {{- end }}
   {{- end }}
   rules:
     - backendRefs:
-        - name: {{ .Values.clusterServerLb.name }}
-          port: {{ .Values.clusterServerLb.service.grpcPort }}
-      {{- with .Values.clusterServerLb.grpcRoute.matches }}
+        - name: {{ $.Values.clusterServerLb.name }}
+          port: {{ $svcPort }}
+      {{- with $httpRoute.matches }}
       matches:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.clusterServerLb.grpcRoute.filters }}
+      {{- with $httpRoute.filters }}
       filters:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/sophora-cluster-common/templates/lb/grpcRoute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/grpcRoute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterServerLb.grpcRoute.enabled -}}
+{{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.grpcRoute.enabled -}}
   {{- $fullName := include "sophora-cluster-common.fullname" . -}}
   {{- $labels := include "sophora-cluster-common.labels" . -}}
 apiVersion: gateway.networking.k8s.io/v1
@@ -6,7 +6,7 @@ kind: GRPCRoute
 metadata:
   name: {{ $fullName }}
   labels:
-  {{ $labels | nindent 4 }}
+  {{- $labels | nindent 4 }}
   {{- with .Values.clusterServerLb.grpcRoute.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
@@ -24,7 +24,7 @@ spec:
   {{- end }}
   rules:
     - backendRefs:
-        - name: {{ $fullName }}
+        - name: {{ .Values.clusterServerLb.name }}
           port: {{ .Values.clusterServerLb.service.grpcPort }}
       {{- with .Values.clusterServerLb.grpcRoute.matches }}
       matches:

--- a/charts/sophora-cluster-common/templates/lb/httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/httproute.yaml
@@ -26,7 +26,7 @@ spec:
   {{- end }}
   rules:
     - backendRefs:
-        - name: {{ $fullName }}
+        - name: {{ $.Values.clusterServerLb.name }}
           port: {{ $svcPort }}
       {{- with $httpRoute.matches }}
       matches:

--- a/charts/sophora-cluster-common/templates/lb/httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/httproute.yaml
@@ -1,0 +1,40 @@
+{{- $fullName := include "sophora-cluster-common.fullname" . -}}
+{{- $labels := include "sophora-cluster-common.labels" . -}}
+{{- $svcPort := .Values.clusterServerLb.service.httpPort -}}
+{{- range $nameSuffix := (.Values.clusterServerLb.httpRoutes | keys | sortAlpha) }}
+{{- $httpRoute := index $.Values.clusterServerLb.httpRoutes $nameSuffix }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-%s" $fullName $nameSuffix | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- $labels | nindent 4 }}
+  {{- with $httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $httpRoute.parentRefs }}
+  parentRefs:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if $httpRoute.hostnames }}
+  hostnames:
+  {{- range $httpRoute.hostnames }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $svcPort }}
+      {{- with $httpRoute.matches }}
+      matches:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $httpRoute.filters }}
+      filters:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+{{- end }}

--- a/charts/sophora-cluster-common/templates/lb/httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/httproute.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clusterServerLb.grpcRoute.enabled -}}
+{{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.httpRoutes -}}
   {{- $fullName := include "sophora-cluster-common.fullname" . -}}
   {{- $labels := include "sophora-cluster-common.labels" . -}}
   {{- $svcPort := .Values.clusterServerLb.service.httpPort -}}

--- a/charts/sophora-cluster-common/templates/lb/httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/httproute.yaml
@@ -1,8 +1,9 @@
-{{- $fullName := include "sophora-cluster-common.fullname" . -}}
-{{- $labels := include "sophora-cluster-common.labels" . -}}
-{{- $svcPort := .Values.clusterServerLb.service.httpPort -}}
-{{- range $nameSuffix := (.Values.clusterServerLb.httpRoutes | keys | sortAlpha) }}
-{{- $httpRoute := index $.Values.clusterServerLb.httpRoutes $nameSuffix }}
+{{- if and .Values.clusterServerLb.grpcRoute.enabled -}}
+  {{- $fullName := include "sophora-cluster-common.fullname" . -}}
+  {{- $labels := include "sophora-cluster-common.labels" . -}}
+  {{- $svcPort := .Values.clusterServerLb.service.httpPort -}}
+  {{- range $nameSuffix := (.Values.clusterServerLb.httpRoutes | keys | sortAlpha) }}
+  {{- $httpRoute := index $.Values.clusterServerLb.httpRoutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -37,4 +38,5 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/sophora-cluster-common/templates/lb/httproute.yaml
+++ b/charts/sophora-cluster-common/templates/lb/httproute.yaml
@@ -1,9 +1,9 @@
 {{- if and .Values.clusterServerLb.enabled .Values.clusterServerLb.httpRoutes -}}
-  {{- $fullName := include "sophora-cluster-common.fullname" . -}}
-  {{- $labels := include "sophora-cluster-common.labels" . -}}
-  {{- $svcPort := .Values.clusterServerLb.service.httpPort -}}
-  {{- range $nameSuffix := (.Values.clusterServerLb.httpRoutes | keys | sortAlpha) }}
-  {{- $httpRoute := index $.Values.clusterServerLb.httpRoutes $nameSuffix }}
+{{- $fullName := include "sophora-cluster-common.fullname" . -}}
+{{- $labels := include "sophora-cluster-common.labels" . -}}
+{{- $svcPort := .Values.clusterServerLb.service.httpPort -}}
+{{- range $nameSuffix := (.Values.clusterServerLb.httpRoutes | keys | sortAlpha) }}
+{{- $httpRoute := index $.Values.clusterServerLb.httpRoutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/sophora-cluster-common/templates/lb/service.yaml
+++ b/charts/sophora-cluster-common/templates/lb/service.yaml
@@ -22,7 +22,7 @@ spec:
       targetPort: jms
       protocol: TCP
       name: jms
-    {{- if .Values.clusterServerLb.grpcIngress.enabled }}
+    {{- if or .Values.clusterServerLb.grpcIngress.enabled .Values.clusterServerLb.grpcRoute.enabled .Values.clusterServerLb.grpcHttproute.enabled }}
     - port: {{ .Values.clusterServerLb.service.grpcPort }}
       targetPort: grpc
       protocol: TCP

--- a/charts/sophora-cluster-common/templates/lb/service.yaml
+++ b/charts/sophora-cluster-common/templates/lb/service.yaml
@@ -22,7 +22,7 @@ spec:
       targetPort: jms
       protocol: TCP
       name: jms
-    {{- if or .Values.clusterServerLb.grpcIngress.enabled .Values.clusterServerLb.grpcRoute.enabled .Values.clusterServerLb.grpcHttproute.enabled }}
+    {{- if or .Values.clusterServerLb.grpcIngress.enabled .Values.clusterServerLb.grpcRoutes .Values.clusterServerLb.grpcHttproutes }}
     - port: {{ .Values.clusterServerLb.service.grpcPort }}
       targetPort: grpc
       protocol: TCP

--- a/charts/sophora-cluster-common/test-values.yaml
+++ b/charts/sophora-cluster-common/test-values.yaml
@@ -26,3 +26,5 @@ prometheusRules:
 
 extraDeploy:
   - apiVersion: subshell/v2
+    metadata:
+      name: my-extra

--- a/charts/sophora-cluster-common/tests/grpcroute_test.yaml
+++ b/charts/sophora-cluster-common/tests/grpcroute_test.yaml
@@ -61,9 +61,9 @@ tests:
                         - name: X-Custom-Header
                           value: custom-value
                 matches:
-                  - path:
-                      type: PathPrefix
-                      value: /
+                  - method:
+                      type: RegularExpression
+                      service: sophora\.srpc.*
       - notFailedTemplate: {}
 
   - it: should not template the service with the grpc port by default

--- a/charts/sophora-cluster-common/tests/grpcroute_test.yaml
+++ b/charts/sophora-cluster-common/tests/grpcroute_test.yaml
@@ -22,12 +22,12 @@ tests:
         containsDocument:
           kind: GRPCRoute
           apiVersion: gateway.networking.k8s.io/v1
-          name: values-test-release-sophora-cluster-common
+          name: values-test-release-sophora-cluster-common-grpc
       - documentIndex: 0
         equal:
           path: metadata
           value:
-            name: values-test-release-sophora-cluster-common
+            name: values-test-release-sophora-cluster-common-grpc
             labels:
               helm.sh/chart: sophora-cluster-common-0.9.8
               app.kubernetes.io/name: sophora-cluster-common

--- a/charts/sophora-cluster-common/tests/grpcroute_test.yaml
+++ b/charts/sophora-cluster-common/tests/grpcroute_test.yaml
@@ -1,16 +1,19 @@
 suite: test grpcroute
 templates:
   - lb/grpcRoute.yaml
+  - lb/service.yaml
 chart:
   version: 0.9.8
   appVersion: 1.2.3
 tests:
   - it: should not create grpcroute by default
+    template: lb/grpcRoute.yaml
     asserts:
       - hasDocuments:
           count: 0
 
   - it: should create multiple grpcroutes with values
+    template: lb/grpcRoute.yaml
     release:
       name: values-test-release
     values:
@@ -61,4 +64,42 @@ tests:
                   - path:
                       type: PathPrefix
                       value: /
+      - notFailedTemplate: {}
+
+  - it: should not template the service with the grpc port by default
+    template: lb/service.yaml
+    set:
+      clusterServerLb.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - notContains:
+          path: spec.ports
+          content:
+            port: 2026
+            targetPort: grpc
+            protocol: TCP
+            name: grpc
+      - notFailedTemplate: {}
+
+  - it: should template the service with the grpc port when grpc routes are configured
+    template: lb/service.yaml
+    release:
+      name: values-test-release
+    values:
+      - ./values/grpcroute.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - contains:
+          path: spec.ports
+          content:
+            port: 2026
+            targetPort: grpc
+            protocol: TCP
+            name: grpc
       - notFailedTemplate: {}

--- a/charts/sophora-cluster-common/tests/grpcroute_test.yaml
+++ b/charts/sophora-cluster-common/tests/grpcroute_test.yaml
@@ -1,0 +1,63 @@
+suite: test httproute
+templates:
+  - lb/grpcRoute.yaml
+chart:
+  version: 0.9.8
+  appVersion: 1.2.3
+tests:
+  - it: should not create httproute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create multiple httproutes with values
+    release:
+      name: values-test-release
+    values:
+      - ./values/grpcroute.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        containsDocument:
+          kind: GRPCRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: values-test-release-sophora-cluster-common
+      - documentIndex: 0
+        equal:
+          path: metadata
+          value:
+            name: values-test-release-sophora-cluster-common
+            labels:
+              helm.sh/chart: sophora-cluster-common-0.9.8
+              app.kubernetes.io/name: sophora-cluster-common
+              app.kubernetes.io/version: 1.2.3
+              app.kubernetes.io/instance: values-test-release
+              app.kubernetes.io/managed-by: Helm
+            annotations:
+              example.com/test: "simple"
+              example.com/text: some text value
+      - documentIndex: 0
+        equal:
+          path: spec
+          value:
+            parentRefs:
+              - name: my-gateway
+                namespace: gateway-namespace
+            hostnames:
+              - my-service.example.com
+              - other.example.com
+            rules:
+              - backendRefs:
+                  - name: cluster-server-lb
+                    port: 2026
+                filters:
+                  - type: RequestHeaderModifier
+                    requestHeaderModifier:
+                      set:
+                        - name: X-Custom-Header
+                          value: custom-value
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /

--- a/charts/sophora-cluster-common/tests/httproute_test.yaml
+++ b/charts/sophora-cluster-common/tests/httproute_test.yaml
@@ -1,0 +1,93 @@
+suite: test httproute
+templates:
+  - lb/httproute.yaml
+chart:
+  version: 0.9.8
+  appVersion: 1.2.3
+tests:
+  - it: should not create httproute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create multiple httproutes with values
+    release:
+      name: values-test-release
+    values:
+      - ./values/httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        containsDocument:
+          kind: HTTPRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: values-test-release-sophora-cluster-common-primary
+      - documentIndex: 1
+        containsDocument:
+          kind: HTTPRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: values-test-release-sophora-cluster-common-secondary
+      - documentIndex: 0
+        equal:
+          path: metadata
+          value:
+            name: values-test-release-sophora-cluster-common-primary
+            labels:
+              helm.sh/chart: sophora-cluster-common-0.9.8
+              app.kubernetes.io/name: sophora-cluster-common
+              app.kubernetes.io/version: 1.2.3
+              app.kubernetes.io/instance: values-test-release
+              app.kubernetes.io/managed-by: Helm
+            annotations:
+              example.com/test: "simple"
+              example.com/text: some text value
+      - documentIndex: 0
+        equal:
+          path: spec
+          value:
+            parentRefs:
+              - name: my-gateway
+                namespace: gateway-namespace
+            hostnames:
+              - my-service.example.com
+              - other.example.com
+            rules:
+              - backendRefs:
+                  - name: cluster-server-lb
+                    port: 1196
+                filters:
+                  - type: RequestHeaderModifier
+                    requestHeaderModifier:
+                      set:
+                        - name: X-Custom-Header
+                          value: custom-value
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+      - documentIndex: 1
+        equal:
+          path: metadata
+          value:
+            name: values-test-release-sophora-cluster-common-secondary
+            labels:
+              helm.sh/chart: sophora-cluster-common-0.9.8
+              app.kubernetes.io/name: sophora-cluster-common
+              app.kubernetes.io/version: 1.2.3
+              app.kubernetes.io/instance: values-test-release
+              app.kubernetes.io/managed-by: Helm
+      - documentIndex: 1
+        equal:
+          path: spec
+          value:
+            parentRefs:
+              - name: my-gateway
+                namespace: gateway-namespace
+            hostnames:
+              - second.example.com
+            rules:
+              - backendRefs:
+                  - name: cluster-server-lb
+                    port: 1196
+      - notFailedTemplate: {}

--- a/charts/sophora-cluster-common/tests/values/grpcroute.yaml
+++ b/charts/sophora-cluster-common/tests/values/grpcroute.yaml
@@ -1,23 +1,23 @@
 clusterServerLb:
   enabled: true
-  grpcRoute:
-    enabled: true
-    parentRefs:
-    - name: my-gateway
-      namespace: gateway-namespace
-    hostnames:
-    - my-service.example.com
-    - other.example.com
-    matches:
-    - path:
-        type: PathPrefix
-        value: /
-    filters:
-    - type: RequestHeaderModifier
-      requestHeaderModifier:
-        set:
-        - name: X-Custom-Header
-          value: custom-value
-    annotations:
-      example.com/test: simple
-      example.com/text: some text value
+  grpcRoutes:
+    grpc:
+      parentRefs:
+      - name: my-gateway
+        namespace: gateway-namespace
+      hostnames:
+      - my-service.example.com
+      - other.example.com
+      matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Custom-Header
+            value: custom-value
+      annotations:
+        example.com/test: simple
+        example.com/text: some text value

--- a/charts/sophora-cluster-common/tests/values/grpcroute.yaml
+++ b/charts/sophora-cluster-common/tests/values/grpcroute.yaml
@@ -1,0 +1,23 @@
+clusterServerLb:
+  enabled: true
+  grpcRoute:
+    enabled: true
+    parentRefs:
+    - name: my-gateway
+      namespace: gateway-namespace
+    hostnames:
+    - my-service.example.com
+    - other.example.com
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Custom-Header
+          value: custom-value
+    annotations:
+      example.com/test: simple
+      example.com/text: some text value

--- a/charts/sophora-cluster-common/tests/values/grpcroute.yaml
+++ b/charts/sophora-cluster-common/tests/values/grpcroute.yaml
@@ -9,9 +9,9 @@ clusterServerLb:
       - my-service.example.com
       - other.example.com
       matches:
-      - path:
-          type: PathPrefix
-          value: /
+      - method:
+          type: RegularExpression
+          service: sophora\.srpc.*
       filters:
       - type: RequestHeaderModifier
         requestHeaderModifier:

--- a/charts/sophora-cluster-common/tests/values/httproute.yaml
+++ b/charts/sophora-cluster-common/tests/values/httproute.yaml
@@ -1,0 +1,29 @@
+clusterServerLb:
+  enabled: true
+  httpRoutes:
+    primary:
+      parentRefs:
+      - name: my-gateway
+        namespace: gateway-namespace
+      hostnames:
+      - my-service.example.com
+      - other.example.com
+      matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - type: RequestHeaderModifier
+        requestHeaderModifier:
+          set:
+          - name: X-Custom-Header
+            value: custom-value
+      annotations:
+        example.com/test: simple
+        example.com/text: some text value
+    secondary:
+      parentRefs:
+      - name: my-gateway
+        namespace: gateway-namespace
+      hostnames:
+      - second.example.com

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -94,7 +94,7 @@ clusterServerLb:
     #   matches:
     #     - path:
     #         type: PathPrefix
-    #         value: /
+    #         value: /sophora.srpc
     #   # httpRoutes.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
     #   filters:
     #     - type: RequestHeaderModifier
@@ -121,7 +121,7 @@ clusterServerLb:
     #   matches:
     #     - path:
     #         type: PathPrefix
-    #         value: /
+    #         value: /sophora.srpc
     #   # grpcRoutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
     #   filters:
     #     - type: RequestHeaderModifier

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -110,26 +110,26 @@ clusterServerLb:
   # The service can be matched since all SRPC-calls have the sophora.srpc package
   grpcRoutes: {}
     # grpc:
-    #   # grpcRoutes.grpc.parentRefs References to the Gateway resources that the HTTPRoute should attach to
+    #   # grpcRoutes.grpc.parentRefs References to the Gateway resources that the GRPCRoute should attach to
     #   parentRefs:
     #     - name: my-gateway
     #       namespace: gateway-namespace
-    #   # grpcRoutes.grpc.hostnames Array with hostnames used for the HTTPRoute
+    #   # grpcRoutes.grpc.hostnames Array with hostnames used for the GRPCRoute
     #   hostnames:
     #     - "my-service.example.com"
-    #   # grpcRoutes.grpc.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+    #   # grpcRoutes.grpc.matches Optional array of GRPCRouteMatch objects for matching gRPC requests
     #   matches:
-    #     - path:
-    #         type: PathPrefix
-    #         value: /sophora.srpc
-    #   # grpcRoutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+    #     - method:
+    #         type: RegularExpression
+    #         service: sophora\.srpc.*
+    #   # grpcRoutes.grpc.filters Optional array of GRPCRouteFilter objects for modifying requests/responses
     #   filters:
     #     - type: RequestHeaderModifier
     #       requestHeaderModifier:
     #         set:
     #           - name: X-Custom-Header
     #             value: custom-value
-    #   # grpcRoutes.grpc.annotations annotations for the HTTPRoute
+    #   # grpcRoutes.grpc.annotations annotations for the GRPCRoute
     #   annotations: {}
 
   service:

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -204,7 +204,7 @@ extraDeploy: []
 # gcp.healthCheck.path HTTP path GCP should use to check the application's health
 # gcp.healthCheck.logging Whether to enable access logging for GCP Health Check requests
 # gcp.grpcHealthCheck.enabled Whether the GCP Health Check resource should be deployed for gRPC
-# gcp.grpcHealthCheck.logging Whether to enable access logging for GCP Health Check requests for
+# gcp.grpcHealthCheck.logging Whether to enable access logging for GCP Health Check requests for gRPC
 gcp:
   healthCheck:
     enabled: false

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -78,7 +78,7 @@ clusterServerLb:
     #   # httpRoutes.web.annotations annotations for the HTTPRoute
     #   annotations: {}
 
-  # This can be used to configure a different HttpRoute for the SRPC service as it might require different settings. Can be used with the same hostname as httpRoute, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
+  # This can be used to configure a different HTTPRoute for the SRPC service as it might require different settings. Can be used with the same hostname as `httpRoutes`, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
   # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
   # The paths can be regex-matched since all SRPC-calls have the root-path sophora.srpc
   grpcHttproute:
@@ -108,7 +108,7 @@ clusterServerLb:
     filters: []
     annotations: {}
 
-  # This can be used to configure a GRPCRoute for the SRPC service. This must use another hostname than `httpRoute`. For the same hostname use `grpcHttproute`.
+  # This can be used to configure a GRPCRoute for the SRPC service. This must use another hostname than `httpRoutes`. For the same hostname use `grpcHttproute`.
   # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
   # The service can be matched since all SRPC-calls have the sophora.srpc package
   grpcRoute:

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -90,19 +90,19 @@ clusterServerLb:
     #   # grpcHttproutes.grpc.hostnames Array with hostnames used for the HTTPRoute
     #   hostnames:
     #     - "my-service.example.com"
-    #   # httpRoutes.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+    #   # grpcHttproutes.grpc.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
     #   matches:
     #     - path:
     #         type: PathPrefix
     #         value: /sophora.srpc
-    #   # httpRoutes.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+    #   # grpcHttproutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
     #   filters:
     #     - type: RequestHeaderModifier
     #       requestHeaderModifier:
     #         set:
     #           - name: X-Custom-Header
     #             value: custom-value
-    #   # httpRoutes.annotations annotations for the HTTPRoute
+    #   # grpcHttproutes.grpc.annotations annotations for the HTTPRoute
     #   annotations: {}
 
   # This can be used to configure multiple GRPCRoute for the SRPC service. This must use another hostname than `httpRoutes`. For the same hostname use `grpcHttproutes`.

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -78,65 +78,59 @@ clusterServerLb:
     #   # httpRoutes.web.annotations annotations for the HTTPRoute
     #   annotations: {}
 
-  # This can be used to configure a different HTTPRoute for the SRPC service as it might require different settings. Can be used with the same hostname as `httpRoutes`, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
+  # This can be used to configure different HTTPRoute for the SRPC service as it might require different settings. Can be used with the same hostname as `httpRoutes`, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
   # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
   # The paths can be regex-matched since all SRPC-calls have the root-path sophora.srpc
-  grpcHttproute:
-    enabled: false
-    # parentRefs:
-    #   - name: my-gateway
-    #     namespace: gateway-namespace
-    parentRefs: []
-    # hostnames:
-    #   - "server.example.com"
-    hostnames: []
-    # matches Optional array of HTTPRouteMatch objects for matching HTTP requests
-    # e.g.
-    # matches:
-    #   - path:
-    #       type: PathPrefix
-    #       value: /sophora.srpc
-    matches: []
-    # filters Optional array of HTTPRouteFilter objects for modifying requests/responses
-    # e.g.
-    # filters:
-    #   - type: RequestHeaderModifier
-    #     requestHeaderModifier:
-    #       set:
-    #         - name: X-Custom-Header
-    #           value: custom-value
-    filters: []
-    annotations: {}
+  grpcHttproutes: {}
+    # grpc:
+    #   # grpcHttproutes.grpc.parentRefs References to the Gateway resources that the HTTPRoute should attach to
+    #   parentRefs:
+    #     - name: my-gateway
+    #       namespace: gateway-namespace
+    #   # grpcHttproutes.grpc.hostnames Array with hostnames used for the HTTPRoute
+    #   hostnames:
+    #     - "my-service.example.com"
+    #   # httpRoutes.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+    #   matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   # httpRoutes.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+    #   filters:
+    #     - type: RequestHeaderModifier
+    #       requestHeaderModifier:
+    #         set:
+    #           - name: X-Custom-Header
+    #             value: custom-value
+    #   # httpRoutes.annotations annotations for the HTTPRoute
+    #   annotations: {}
 
-  # This can be used to configure a GRPCRoute for the SRPC service. This must use another hostname than `httpRoutes`. For the same hostname use `grpcHttproute`.
+  # This can be used to configure multiple GRPCRoute for the SRPC service. This must use another hostname than `httpRoutes`. For the same hostname use `grpcHttproutes`.
   # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
   # The service can be matched since all SRPC-calls have the sophora.srpc package
-  grpcRoute:
-    enabled: false
-    # parentRefs:
-    #   - name: my-gateway
-    #     namespace: gateway-namespace
-    parentRefs: []
-    # hostnames:
-    #   - "server.example.com"
-    hostnames: []
-    # matches Optional array of GRPCRouteMatch objects for matching gRPC requests
-    # e.g.
-    # matches:
-    #   - method:
-    #       type: RegularExpression
-    #       service : sophora\.srpc.*
-    matches: []
-    # filters Optional array of GRPCRouteFilter objects for modifying requests/responses
-    # e.g.
-    # filters:
-    #   - type: RequestHeaderModifier
-    #     requestHeaderModifier:
-    #       set:
-    #         - name: X-Custom-Header
-    #           value: custom-value
-    filters: []
-    annotations: {}
+  grpcRoutes: {}
+    # grpc:
+    #   # grpcRoutes.grpc.parentRefs References to the Gateway resources that the HTTPRoute should attach to
+    #   parentRefs:
+    #     - name: my-gateway
+    #       namespace: gateway-namespace
+    #   # grpcRoutes.grpc.hostnames Array with hostnames used for the HTTPRoute
+    #   hostnames:
+    #     - "my-service.example.com"
+    #   # grpcRoutes.grpc.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+    #   matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   # grpcRoutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+    #   filters:
+    #     - type: RequestHeaderModifier
+    #       requestHeaderModifier:
+    #         set:
+    #           - name: X-Custom-Header
+    #             value: custom-value
+    #   # grpcRoutes.grpc.annotations annotations for the HTTPRoute
+    #   annotations: {}
 
   service:
     # clusterServerLb.service.type Kubernetes service type

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -52,6 +52,92 @@ clusterServerLb:
     #    hosts:
     #      - chart-example.local
 
+  # httpRoutes Map of HTTPRoute resources (Gateway API) to create.
+  # The map key is used as a suffix for the resource name, e.g. "web" -> "<fullname>-web".
+  httpRoutes: {}
+    # web:
+    #   # httpRoutes.web.parentRefs References to the Gateway resources that the HTTPRoute should attach to
+    #   parentRefs:
+    #     - name: my-gateway
+    #       namespace: gateway-namespace
+    #   # httpRoutes.web.hostnames Array with hostnames used for the HTTPRoute
+    #   hostnames:
+    #     - "my-service.example.com"
+    #   # httpRoutes.web.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+    #   matches:
+    #     - path:
+    #         type: PathPrefix
+    #         value: /
+    #   # httpRoutes.web.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+    #   filters:
+    #     - type: RequestHeaderModifier
+    #       requestHeaderModifier:
+    #         set:
+    #           - name: X-Custom-Header
+    #             value: custom-value
+    #   # httpRoutes.web.annotations annotations for the HTTPRoute
+    #   annotations: {}
+
+  # This can be used to configure a different HttpRoute for the SRPC service as it might require different settings. Can be used with the same hostname as httpRoute, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
+  # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
+  # The paths can be regex-matched since all SRPC-calls have the root-path sophora.srpc
+  grpcHttproute:
+    enabled: false
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-namespace
+    parentRefs: []
+    # hostnames:
+    #   - "server.example.com"
+    hostnames: []
+    # matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+    # e.g.
+    # matches:
+    #   - path:
+    #       type: PathPrefix
+    #       value: /sophora.srpc
+    matches: []
+    # filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+    # e.g.
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       set:
+    #         - name: X-Custom-Header
+    #           value: custom-value
+    filters: []
+    annotations: {}
+
+  # This can be used to configure a GRPCRoute for the SRPC service. This must use another hostname than `httpRoute`. For the same hostname use `grpcHttproute`.
+  # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
+  # The service can be matched since all SRPC-calls have the sophora.srpc package
+  grpcRoute:
+    enabled: false
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-namespace
+    parentRefs: []
+    # hostnames:
+    #   - "server.example.com"
+    hostnames: []
+    # matches Optional array of GRPCRouteMatch objects for matching gRPC requests
+    # e.g.
+    # matches:
+    #   - method:
+    #       type: RegularExpression
+    #       service : sophora\.srpc.*
+    matches: []
+    # filters Optional array of GRPCRouteFilter objects for modifying requests/responses
+    # e.g.
+    # filters:
+    #   - type: RequestHeaderModifier
+    #     requestHeaderModifier:
+    #       set:
+    #         - name: X-Custom-Header
+    #           value: custom-value
+    filters: []
+    annotations: {}
+
   service:
     # clusterServerLb.service.type Kubernetes service type
     type: ClusterIP
@@ -117,9 +203,14 @@ extraDeploy: []
 # gcp.healthCheck.portName Name of the port used for the GCP Health Check
 # gcp.healthCheck.path HTTP path GCP should use to check the application's health
 # gcp.healthCheck.logging Whether to enable access logging for GCP Health Check requests
+# gcp.grpcHealthCheck.enabled Whether the GCP Health Check resource should be deployed for gRPC
+# gcp.grpcHealthCheck.logging Whether to enable access logging for GCP Health Check requests for
 gcp:
   healthCheck:
     enabled: false
     logging: false
     portName: http
     path: "/status/ready"
+  grpcHealthCheck:
+    enabled: false
+    logging: false

--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -20,6 +20,8 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: "Added GCP HealthCheckPolicy support for gRPC, use topLevelLabels for routes"
+    - kind: changed
+      description: "breaking change: support multiple gRPC HTTPRoutes. Renamed `grpcHttproute/grpcRoute` to `grpcHttproutes/grpcRoutes`."
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -19,7 +19,7 @@ version: 3.7.0
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Added GCP HealthCheckPolicy support for gRPC"
+      description: "Added GCP HealthCheckPolicy support for gRPC, use topLevelLabels for routes"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -19,7 +19,7 @@ version: 3.7.0
 annotations:
   artifacthub.io/changes: |
     - kind: added
-      description: "Added gRPC GCP HealthCheckFixed support"
+      description: "Added GCP HealthCheckPolicy support for gRPC"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.6.3
+version: 3.7.0
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: added
+      description: "Added gRPC GCP HealthCheckFixed support"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
@@ -1,7 +1,7 @@
 {{- if and .Values.gcp.grpcHealthCheck.enabled .Values.sophora.grpcApi.enabled -}}
 ---
 {{- $fullName := include "sophora-server.fullname" . -}}
-{{- $labels := include "sophora-server.labels" . -}}
+{{- $labels := include "sophora-server.topLevelLabels" . -}}
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:

--- a/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
@@ -5,7 +5,7 @@
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:
-  name: {{ $fullName }}
+  name: {{ printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
   labels:
     {{- $labels | nindent 4 }}
 spec:

--- a/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.gcp.grpcHealthCheck.enabled .Values.sophora.grpcApi.enabled -}}
+---
+{{- $fullName := include "sophora-server.fullname" . -}}
+{{- $labels := include "sophora-server.labels" . -}}
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  default:
+    config:
+      type: GRPC
+      grpcHealthCheck:
+        port: {{ .Values.sophora.server.ports.grpc }}
+    logConfig:
+      enabled: {{ .Values.gcp.grpcHealthCheck.logging }}
+  targetRef:
+    group: ""
+    kind: Service
+    name: {{ $fullName }}
+{{- end }}

--- a/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
+++ b/charts/sophora-server/templates/gcpGRPCHealthCheck.yaml
@@ -13,7 +13,7 @@ spec:
     config:
       type: GRPC
       grpcHealthCheck:
-        port: {{ .Values.sophora.server.ports.grpc }}
+        port: {{ .Values.service.grpcPort }}
     logConfig:
       enabled: {{ .Values.gcp.grpcHealthCheck.logging }}
   targetRef:

--- a/charts/sophora-server/templates/gcpHealthCheck.yaml
+++ b/charts/sophora-server/templates/gcpHealthCheck.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.gcp.healthCheck.enabled }}
 ---
 {{- $fullName := include "sophora-server.fullname" . -}}
-{{- $labels := include "sophora-server.labels" . -}}
+{{- $labels := include "sophora-server.topLevelLabels" . -}}
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
 metadata:

--- a/charts/sophora-server/templates/grpc-httproute.yaml
+++ b/charts/sophora-server/templates/grpc-httproute.yaml
@@ -24,7 +24,7 @@ spec:
   rules:
     - backendRefs:
         - name: {{ $fullName }}
-          port: {{ .Values.sophora.server.ports.grpc }}
+          port: {{ .Values.service.grpcPort }}
       {{- with .Values.grpcHttproute.matches }}
       matches:
       {{- toYaml . | nindent 8 }}

--- a/charts/sophora-server/templates/grpc-httproute.yaml
+++ b/charts/sophora-server/templates/grpc-httproute.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "sophora-server.fullname" . -}}
 {{- $labels := include "sophora-server.topLevelLabels" . -}}
 {{- $svcPort := .Values.service.grpcPort -}}
+{{- $nameSuffix := "grpc" }}
 {{- with .Values.grpcHttproute }}
 {{- $httpRoute := . }}
-{{- $nameSuffix := "grpc" }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/sophora-server/templates/grpc-httproute.yaml
+++ b/charts/sophora-server/templates/grpc-httproute.yaml
@@ -1,36 +1,43 @@
 {{- if and .Values.grpcHttproute.enabled .Values.sophora.grpcApi.enabled -}}
-  {{- $fullName := include "sophora-server.fullname" . -}}
-  {{- $routeName := printf "%s-grpc" ($fullName | trunc 58 | trimSuffix "-") }}
+{{- $fullName := include "sophora-server.fullname" . -}}
+{{- $labels := include "sophora-server.topLevelLabels" . -}}
+{{- $svcPort := .Values.service.grpcPort -}}
+{{- with .Values.grpcHttproute }}
+{{- $httpRoute := . }}
+{{- $nameSuffix := "grpc" }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $routeName }}
-  labels: {{ include "sophora-server.topLevelLabels" . | nindent 4 }}
-  {{- with .Values.grpcHttproute.annotations }}
+  name: {{ printf "%s-%s" $fullName $nameSuffix | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- $labels | nindent 4 }}
+  {{- with $httpRoute.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.grpcHttproute.parentRefs }}
+  {{- with $httpRoute.parentRefs }}
   parentRefs:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.grpcHttproute.hostnames }}
+  {{- if $httpRoute.hostnames }}
   hostnames:
-  {{- range .Values.grpcHttproute.hostnames }}
+  {{- range $httpRoute.hostnames }}
     - {{ . | quote }}
   {{- end }}
   {{- end }}
   rules:
     - backendRefs:
         - name: {{ $fullName }}
-          port: {{ .Values.service.grpcPort }}
-      {{- with .Values.grpcHttproute.matches }}
+          port: {{ $svcPort }}
+      {{- with $httpRoute.matches }}
       matches:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.grpcHttproute.filters }}
+      {{- with $httpRoute.filters }}
       filters:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/sophora-server/templates/grpc-httproute.yaml
+++ b/charts/sophora-server/templates/grpc-httproute.yaml
@@ -1,10 +1,9 @@
-{{- if and .Values.grpcHttproute.enabled .Values.sophora.grpcApi.enabled -}}
+{{- if .Values.sophora.grpcApi.enabled -}}
 {{- $fullName := include "sophora-server.fullname" . -}}
 {{- $labels := include "sophora-server.topLevelLabels" . -}}
 {{- $svcPort := .Values.service.grpcPort -}}
-{{- $nameSuffix := "grpc" }}
-{{- with .Values.grpcHttproute }}
-{{- $httpRoute := . }}
+{{- range $nameSuffix := (.Values.grpcHttproutes | keys | sortAlpha) }}
+{{- $httpRoute := index $.Values.grpcHttproutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/sophora-server/templates/grpcRoute.yaml
+++ b/charts/sophora-server/templates/grpcRoute.yaml
@@ -23,7 +23,7 @@ spec:
   rules:
     - backendRefs:
         - name: {{ $fullName }}
-          port: {{ .Values.sophora.server.ports.grpc }}
+          port: {{ .Values.service.grpcPort }}
       {{- with .Values.grpcRoute.matches }}
       matches:
       {{- toYaml . | nindent 8 }}

--- a/charts/sophora-server/templates/grpcRoute.yaml
+++ b/charts/sophora-server/templates/grpcRoute.yaml
@@ -2,9 +2,9 @@
 {{- $fullName := include "sophora-server.fullname" . -}}
 {{- $labels := include "sophora-server.topLevelLabels" . -}}
 {{- $svcPort := .Values.service.grpcPort -}}
+{{- $nameSuffix := "grpc" }}
 {{- with .Values.grpcRoute }}
 {{- $httpRoute := . }}
-{{- $nameSuffix := "grpc" }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:

--- a/charts/sophora-server/templates/grpcRoute.yaml
+++ b/charts/sophora-server/templates/grpcRoute.yaml
@@ -1,10 +1,9 @@
-{{- if and .Values.grpcRoute.enabled .Values.sophora.grpcApi.enabled -}}
+{{- if .Values.sophora.grpcApi.enabled -}}
 {{- $fullName := include "sophora-server.fullname" . -}}
 {{- $labels := include "sophora-server.topLevelLabels" . -}}
 {{- $svcPort := .Values.service.grpcPort -}}
-{{- $nameSuffix := "grpc" }}
-{{- with .Values.grpcRoute }}
-{{- $httpRoute := . }}
+{{- range $nameSuffix := (.Values.grpcRoutes | keys | sortAlpha) }}
+{{- $httpRoute := index $.Values.grpcRoutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:

--- a/charts/sophora-server/templates/grpcRoute.yaml
+++ b/charts/sophora-server/templates/grpcRoute.yaml
@@ -1,35 +1,43 @@
 {{- if and .Values.grpcRoute.enabled .Values.sophora.grpcApi.enabled -}}
-  {{- $fullName := include "sophora-server.fullname" . -}}
+{{- $fullName := include "sophora-server.fullname" . -}}
+{{- $labels := include "sophora-server.topLevelLabels" . -}}
+{{- $svcPort := .Values.service.grpcPort -}}
+{{- with .Values.grpcRoute }}
+{{- $httpRoute := . }}
+{{- $nameSuffix := "grpc" }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GRPCRoute
 metadata:
-  name: {{ $fullName }}
-  labels: {{ include "sophora-server.topLevelLabels" . | nindent 4 }}
-  {{- with .Values.grpcRoute.annotations }}
+  name: {{ printf "%s-%s" $fullName $nameSuffix | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- $labels | nindent 4 }}
+  {{- with $httpRoute.annotations }}
   annotations:
-  {{- toYaml . | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- with .Values.grpcRoute.parentRefs }}
+  {{- with $httpRoute.parentRefs }}
   parentRefs:
   {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.grpcRoute.hostnames }}
+  {{- if $httpRoute.hostnames }}
   hostnames:
-  {{- range .Values.grpcRoute.hostnames }}
+  {{- range $httpRoute.hostnames }}
     - {{ . | quote }}
   {{- end }}
   {{- end }}
   rules:
     - backendRefs:
         - name: {{ $fullName }}
-          port: {{ .Values.service.grpcPort }}
-      {{- with .Values.grpcRoute.matches }}
+          port: {{ $svcPort }}
+      {{- with $httpRoute.matches }}
       matches:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.grpcRoute.filters }}
+      {{- with $httpRoute.filters }}
       filters:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/sophora-server/templates/httproute.yaml
+++ b/charts/sophora-server/templates/httproute.yaml
@@ -1,6 +1,6 @@
 {{- $fullName := include "sophora-server.fullname" . -}}
 {{- $labels := include "sophora-server.topLevelLabels" . -}}
-{{- $svcPort := .Values.sophora.server.ports.http -}}
+{{- $svcPort := .Values.service.httpPort -}}
 {{- range $nameSuffix := (.Values.httpRoutes | keys | sortAlpha) }}
 {{- $httpRoute := index $.Values.httpRoutes $nameSuffix }}
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/sophora-server/tests/grpc-httproute_test.yaml
+++ b/charts/sophora-server/tests/grpc-httproute_test.yaml
@@ -1,0 +1,66 @@
+suite: test grpc-httproute
+templates:
+  - grpc-httproute.yaml
+chart:
+  version: 0.9.8
+set:
+  image.tag: 1.2.3
+tests:
+  - it: should not create grpc-httproute by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create multiple grpc-httproutes with values
+    release:
+      name: values-test-release
+    values:
+      - ./values/grpc-httproute.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - documentIndex: 0
+        containsDocument:
+          kind: HTTPRoute
+          apiVersion: gateway.networking.k8s.io/v1
+          name: values-test-release-sophora-server-grpc
+      - documentIndex: 0
+        equal:
+          path: metadata
+          value:
+            name: values-test-release-sophora-server-grpc
+            labels:
+              helm.sh/chart: sophora-server-0.9.8
+              app.kubernetes.io/name: sophora-server
+              app.kubernetes.io/version: 1.2.3
+              app.kubernetes.io/instance: values-test-release
+              app.kubernetes.io/managed-by: Helm
+              top: label for all resources
+            annotations:
+              example.com/test: "simple"
+              example.com/text: some text value
+      - documentIndex: 0
+        equal:
+          path: spec
+          value:
+            parentRefs:
+              - name: my-gateway
+                namespace: gateway-namespace
+            hostnames:
+              - my-service.example.com
+              - other.example.com
+            rules:
+              - backendRefs:
+                  - name: values-test-release-sophora-server
+                    port: 2026
+                filters:
+                  - type: RequestHeaderModifier
+                    requestHeaderModifier:
+                      set:
+                        - name: X-Custom-Header
+                          value: custom-value
+                matches:
+                  - path:
+                      type: PathPrefix
+                      value: /
+      - notFailedTemplate: {}

--- a/charts/sophora-server/tests/grpcroute_test.yaml
+++ b/charts/sophora-server/tests/grpcroute_test.yaml
@@ -60,7 +60,7 @@ tests:
                         - name: X-Custom-Header
                           value: custom-value
                 matches:
-                  - path:
-                      type: PathPrefix
-                      value: /
+                  - method:
+                      type: RegularExpression
+                      service: sophora\.srpc.*
       - notFailedTemplate: {}

--- a/charts/sophora-server/tests/grpcroute_test.yaml
+++ b/charts/sophora-server/tests/grpcroute_test.yaml
@@ -1,9 +1,10 @@
 suite: test grpcroute
 templates:
-  - lb/grpcRoute.yaml
+  - grpcRoute.yaml
 chart:
   version: 0.9.8
-  appVersion: 1.2.3
+set:
+  image.tag: 1.2.3
 tests:
   - it: should not create grpcroute by default
     asserts:
@@ -22,18 +23,19 @@ tests:
         containsDocument:
           kind: GRPCRoute
           apiVersion: gateway.networking.k8s.io/v1
-          name: values-test-release-sophora-cluster-common
+          name: values-test-release-sophora-server-grpc
       - documentIndex: 0
         equal:
           path: metadata
           value:
-            name: values-test-release-sophora-cluster-common
+            name: values-test-release-sophora-server-grpc
             labels:
-              helm.sh/chart: sophora-cluster-common-0.9.8
-              app.kubernetes.io/name: sophora-cluster-common
+              helm.sh/chart: sophora-server-0.9.8
+              app.kubernetes.io/name: sophora-server
               app.kubernetes.io/version: 1.2.3
               app.kubernetes.io/instance: values-test-release
               app.kubernetes.io/managed-by: Helm
+              top: label for all resources
             annotations:
               example.com/test: "simple"
               example.com/text: some text value
@@ -49,7 +51,7 @@ tests:
               - other.example.com
             rules:
               - backendRefs:
-                  - name: cluster-server-lb
+                  - name: values-test-release-sophora-server
                     port: 2026
                 filters:
                   - type: RequestHeaderModifier

--- a/charts/sophora-server/tests/httproute_test.yaml
+++ b/charts/sophora-server/tests/httproute_test.yaml
@@ -40,6 +40,7 @@ tests:
               app.kubernetes.io/version: 1.2.3
               app.kubernetes.io/instance: values-test-release
               app.kubernetes.io/managed-by: Helm
+              top: label for all resources
             annotations:
               example.com/test: "simple"
               example.com/text: some text value
@@ -78,6 +79,7 @@ tests:
               app.kubernetes.io/version: 1.2.3
               app.kubernetes.io/instance: values-test-release
               app.kubernetes.io/managed-by: Helm
+              top: label for all resources
       - documentIndex: 1
         equal:
           path: spec

--- a/charts/sophora-server/tests/values/grpc-httproute.yaml
+++ b/charts/sophora-server/tests/values/grpc-httproute.yaml
@@ -1,0 +1,31 @@
+sophora:
+  grpcApi:
+    enabled: true
+  server:
+    ports:
+      grpc: 3027 # different as service.grpcPort
+
+topLevelLabels:
+  top: label for all resources
+
+grpcHttproute:
+  enabled: true
+  parentRefs:
+  - name: my-gateway
+    namespace: gateway-namespace
+  hostnames:
+  - my-service.example.com
+  - other.example.com
+  matches:
+  - path:
+      type: PathPrefix
+      value: /
+  filters:
+  - type: RequestHeaderModifier
+    requestHeaderModifier:
+      set:
+      - name: X-Custom-Header
+        value: custom-value
+  annotations:
+    example.com/test: simple
+    example.com/text: some text value

--- a/charts/sophora-server/tests/values/grpc-httproute.yaml
+++ b/charts/sophora-server/tests/values/grpc-httproute.yaml
@@ -8,24 +8,24 @@ sophora:
 topLevelLabels:
   top: label for all resources
 
-grpcHttproute:
-  enabled: true
-  parentRefs:
-  - name: my-gateway
-    namespace: gateway-namespace
-  hostnames:
-  - my-service.example.com
-  - other.example.com
-  matches:
-  - path:
-      type: PathPrefix
-      value: /
-  filters:
-  - type: RequestHeaderModifier
-    requestHeaderModifier:
-      set:
-      - name: X-Custom-Header
-        value: custom-value
-  annotations:
-    example.com/test: simple
-    example.com/text: some text value
+grpcHttproutes:
+  grpc:
+    parentRefs:
+    - name: my-gateway
+      namespace: gateway-namespace
+    hostnames:
+    - my-service.example.com
+    - other.example.com
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Custom-Header
+          value: custom-value
+    annotations:
+      example.com/test: simple
+      example.com/text: some text value

--- a/charts/sophora-server/tests/values/grpcroute.yaml
+++ b/charts/sophora-server/tests/values/grpcroute.yaml
@@ -8,24 +8,24 @@ sophora:
 topLevelLabels:
   top: label for all resources
 
-grpcRoute:
-  enabled: true
-  parentRefs:
-  - name: my-gateway
-    namespace: gateway-namespace
-  hostnames:
-  - my-service.example.com
-  - other.example.com
-  matches:
-  - path:
-      type: PathPrefix
-      value: /
-  filters:
-  - type: RequestHeaderModifier
-    requestHeaderModifier:
-      set:
-      - name: X-Custom-Header
-        value: custom-value
-  annotations:
-    example.com/test: simple
-    example.com/text: some text value
+grpcRoutes:
+  grpc:
+    parentRefs:
+    - name: my-gateway
+      namespace: gateway-namespace
+    hostnames:
+    - my-service.example.com
+    - other.example.com
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        set:
+        - name: X-Custom-Header
+          value: custom-value
+    annotations:
+      example.com/test: simple
+      example.com/text: some text value

--- a/charts/sophora-server/tests/values/grpcroute.yaml
+++ b/charts/sophora-server/tests/values/grpcroute.yaml
@@ -1,0 +1,31 @@
+sophora:
+  grpcApi:
+    enabled: true
+  server:
+    ports:
+      grpc: 3027 # different as service.grpcPort
+
+topLevelLabels:
+  top: label for all resources
+
+grpcRoute:
+  enabled: true
+  parentRefs:
+  - name: my-gateway
+    namespace: gateway-namespace
+  hostnames:
+  - my-service.example.com
+  - other.example.com
+  matches:
+  - path:
+      type: PathPrefix
+      value: /
+  filters:
+  - type: RequestHeaderModifier
+    requestHeaderModifier:
+      set:
+      - name: X-Custom-Header
+        value: custom-value
+  annotations:
+    example.com/test: simple
+    example.com/text: some text value

--- a/charts/sophora-server/tests/values/grpcroute.yaml
+++ b/charts/sophora-server/tests/values/grpcroute.yaml
@@ -17,9 +17,9 @@ grpcRoutes:
     - my-service.example.com
     - other.example.com
     matches:
-    - path:
-        type: PathPrefix
-        value: /
+    - method:
+        type: RegularExpression
+        service: sophora\.srpc.*
     filters:
     - type: RequestHeaderModifier
       requestHeaderModifier:

--- a/charts/sophora-server/tests/values/httproute.yaml
+++ b/charts/sophora-server/tests/values/httproute.yaml
@@ -1,3 +1,11 @@
+sophora:
+  server:
+    ports:
+      http: 2197 # different as service.httpPort
+
+topLevelLabels:
+  top: label for all resources
+
 httpRoutes:
   primary:
     parentRefs:

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -530,7 +530,7 @@ podDisruptionBudget:
 # gcp.healthCheck.path HTTP path GCP should use to check the application's health
 # gcp.healthCheck.logging Whether to enable access logging for GCP Health Check requests
 # gcp.grpcHealthCheck.enabled Whether the GCP Health Check resource should be deployed for gRPC
-# gcp.grpcHealthCheck.logging Whether to enable access logging for GCP Health Check requests for
+# gcp.grpcHealthCheck.logging Whether to enable access logging for GCP Health Check requests for gRPC
 gcp:
   healthCheck:
     enabled: false

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -529,9 +529,14 @@ podDisruptionBudget:
 # gcp.healthCheck.portName Name of the port used for the GCP Health Check
 # gcp.healthCheck.path HTTP path GCP should use to check the application's health
 # gcp.healthCheck.logging Whether to enable access logging for GCP Health Check requests
+# gcp.grpcHealthCheck.enabled Whether the GCP Health Check resource should be deployed for gRPC
+# gcp.grpcHealthCheck.logging Whether to enable access logging for GCP Health Check requests for
 gcp:
   healthCheck:
     enabled: false
     logging: false
     portName: http
     path: "/status/ready"
+  grpcHealthCheck:
+    enabled: false
+    logging: false

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -415,62 +415,56 @@ httpRoutes: {}
 # This can be used to configure a different HttpRoute for the SRPC service as it might require different settings. Can be used with the same hostname as httpRoute, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
 # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
 # The paths can be regex-matched since all SRPC-calls have the root-path sophora.srpc
-grpcHttproute:
-  enabled: false
-  # parentRefs:
-  #   - name: my-gateway
-  #     namespace: gateway-namespace
-  parentRefs: []
-  # hostnames:
-  #   - "server.example.com"
-  hostnames: []
-  # matches Optional array of HTTPRouteMatch objects for matching HTTP requests
-  # e.g.
-  # matches:
-  #   - path:
-  #       type: PathPrefix
-  #       value: /sophora.srpc
-  matches: []
-  # filters Optional array of HTTPRouteFilter objects for modifying requests/responses
-  # e.g.
-  # filters:
-  #   - type: RequestHeaderModifier
-  #     requestHeaderModifier:
-  #       set:
-  #         - name: X-Custom-Header
-  #           value: custom-value
-  filters: []
-  annotations: {}
+grpcHttproutes: {}
+  # grpc:
+  #   # grpcHttproutes.grpc.parentRefs References to the Gateway resources that the HTTPRoute should attach to
+  #   parentRefs:
+  #     - name: my-gateway
+  #       namespace: gateway-namespace
+  #   # grpcHttproutes.grpc.hostnames Array with hostnames used for the HTTPRoute
+  #   hostnames:
+  #     - "my-service.example.com"
+  #   # grpcHttproutes.grpc.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+  #   matches:
+  #     - path:
+  #         type: PathPrefix
+  #         value: /
+  #   # grpcHttproutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+  #   filters:
+  #     - type: RequestHeaderModifier
+  #       requestHeaderModifier:
+  #         set:
+  #           - name: X-Custom-Header
+  #             value: custom-value
+  #   # grpcHttproutes.grpc.annotations annotations for the HTTPRoute
+  #   annotations: {}
 
 # This can be used to configure a GRPCRoute for the SRPC service. This must use another hostname than `httpRoute`. For the same hostname use `grpcHttproute`.
 # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
 # The service can be matched since all SRPC-calls have the sophora.srpc package
-grpcRoute:
-  enabled: false
-  # parentRefs:
-  #   - name: my-gateway
-  #     namespace: gateway-namespace
-  parentRefs: []
-  # hostnames:
-  #   - "server.example.com"
-  hostnames: []
-  # matches Optional array of GRPCRouteMatch objects for matching gRPC requests
-  # e.g.
-  # matches:
-  #   - method:
-  #       type: RegularExpression
-  #       service : sophora\.srpc.*
-  matches: []
-  # filters Optional array of GRPCRouteFilter objects for modifying requests/responses
-  # e.g.
-  # filters:
-  #   - type: RequestHeaderModifier
-  #     requestHeaderModifier:
-  #       set:
-  #         - name: X-Custom-Header
-  #           value: custom-value
-  filters: []
-  annotations: {}
+grpcRoutes: {}
+  # grpc:
+  #   # grpcRoutes.grpc.parentRefs References to the Gateway resources that the HTTPRoute should attach to
+  #   parentRefs:
+  #     - name: my-gateway
+  #       namespace: gateway-namespace
+  #   # grpcRoutes.grpc.hostnames Array with hostnames used for the HTTPRoute
+  #   hostnames:
+  #     - "my-service.example.com"
+  #   # grpcRoutes.grpc.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
+  #   matches:
+  #     - path:
+  #         type: PathPrefix
+  #         value: /
+  #   # grpcRoutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+  #   filters:
+  #     - type: RequestHeaderModifier
+  #       requestHeaderModifier:
+  #         set:
+  #           - name: X-Custom-Header
+  #             value: custom-value
+  #   # grpcRoutes.grpc.annotations annotations for the HTTPRoute
+  #   annotations: {}
 
 service:
   annotations: {}

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -428,7 +428,7 @@ grpcHttproutes: {}
   #   matches:
   #     - path:
   #         type: PathPrefix
-  #         value: /
+  #         value: /sophora.srpc
   #   # grpcHttproutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
   #   filters:
   #     - type: RequestHeaderModifier
@@ -453,9 +453,9 @@ grpcRoutes: {}
   #     - "my-service.example.com"
   #   # grpcRoutes.grpc.matches Optional array of HTTPRouteMatch objects for matching HTTP requests
   #   matches:
-  #     - path:
-  #         type: PathPrefix
-  #         value: /
+  #     - method:
+  #         type: RegularExpression
+  #         service: sophora\.srpc.*
   #   # grpcRoutes.grpc.filters Optional array of GRPCRouteFilter objects for modifying requests/responses
   #   filters:
   #     - type: RequestHeaderModifier

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -412,7 +412,7 @@ httpRoutes: {}
   #   # httpRoutes.web.annotations annotations for the HTTPRoute
   #   annotations: {}
 
-# This can be used to configure a different HttpRoute for the SRPC service as it might require different settings. Can be used with the same hostname as httpRoute, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
+# This can be used to configure a different HTTPRoute for the SRPC service as it might require different settings. Can be used with the same hostname as httpRoutes, see https://gateway-api.sigs.k8s.io/api-types/grpcroute/#cross-serving.
 # The SRPC-communication relies on gRPC as communication protocol and e.g. nginx needs to be explicitly informed that the backend protocol is gRPC
 # The paths can be regex-matched since all SRPC-calls have the root-path sophora.srpc
 grpcHttproutes: {}
@@ -456,14 +456,14 @@ grpcRoutes: {}
   #     - path:
   #         type: PathPrefix
   #         value: /
-  #   # grpcRoutes.grpc.filters Optional array of HTTPRouteFilter objects for modifying requests/responses
+  #   # grpcRoutes.grpc.filters Optional array of GRPCRouteFilter objects for modifying requests/responses
   #   filters:
   #     - type: RequestHeaderModifier
   #       requestHeaderModifier:
   #         set:
   #           - name: X-Custom-Header
   #             value: custom-value
-  #   # grpcRoutes.grpc.annotations annotations for the HTTPRoute
+  #   # grpcRoutes.grpc.annotations annotations for the GRPCRoute
   #   annotations: {}
 
 service:


### PR DESCRIPTION
[TSTCLD-108](https://support.subshell.com/browse/TSTCLD-108)

This pull request introduces enhancements to the sophora-server and sophora-cluster-common Helm charts, primarily adding support for Gateway API HTTPRoute/GRPCRoute resources and GCP gRPC HealthCheckPolicy, along with related configuration and testing improvements. It also includes a breaking change by renaming route configuration keys to support multiple routes. 

**Gateway API and gRPC Enhancements:**

* Added support for creating multiple `HTTPRoute` and `GRPCRoute` resources via new `httpRoutes`, `grpcHttproutes`, and `grpcRoutes` map values in `clusterServerLb`, enabling flexible Gateway API integration for HTTP and gRPC traffic.
* Added support for GCP gRPC `HealthCheckPolicy` resources, configurable via `gcp.grpcHealthCheck` values, and templated in both `sophora-cluster-common` and `sophora-server` charts.

**Breaking Changes:**

* Renamed single route configuration keys (`grpcHttproute`/`grpcRoute`) to plural (`grpcHttproutes`/`grpcRoutes`) to support multiple routes and updated documentation and tests accordingly.

**Service and Template Logic:**

* Updated service port logic to include the gRPC port if any gRPC ingress or routes are enabled, ensuring correct exposure for gRPC traffic.

**Testing and Documentation:**

* Added comprehensive tests and example values for the new `HTTPRoute` and `GRPCRoute` features, ensuring correct rendering and configuration.