### PR TITLE
[all] GCPHealthCheck uses numeric instead of named port by default

### DIFF
--- a/charts/o-neko-catnip/Chart.yaml
+++ b/charts/o-neko-catnip/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: o-neko-catnip
 description: A Helm chart for the O-Neko URL trigger
 type: application
-version: 1.6.3
+version: 1.6.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 appVersion: "1.3.2"
 sources:

--- a/charts/o-neko-catnip/values.yaml
+++ b/charts/o-neko-catnip/values.yaml
@@ -178,6 +178,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    # port:
-    portName: http
+    port: 8080
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/actuator/health"

--- a/charts/o-neko/Chart.yaml
+++ b/charts/o-neko/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: o-neko
 description: A Helm chart for O-Neko
 type: application
-version: 2.3.3
+version: 2.3.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 appVersion: "1.8.2"
 sources:

--- a/charts/o-neko/values.yaml
+++ b/charts/o-neko/values.yaml
@@ -201,6 +201,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    # port:
-    portName: http
+    port: 8080
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/actuator/health"

--- a/charts/planr-tools/Chart.yaml
+++ b/charts/planr-tools/Chart.yaml
@@ -3,11 +3,11 @@ name: planr-tools
 description: A Helm chart for deploying the planr-tools applications
 type: application
 version: 1.3.3
-appVersion: "5.1.1"
+appVersion: "5.1.2"
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 sources:
   - https://github.com/subshell/helm-charts/tree/main/charts/planr-tools
 home: https://gitlab.com/subshell/kunden/planr-tools

--- a/charts/planr-tools/tests/gcphealthcheck_test.yaml
+++ b/charts/planr-tools/tests/gcphealthcheck_test.yaml
@@ -34,8 +34,8 @@ tests:
           name: values-test-release-planr-tools-newsroom-widget
           any: true
       - equal:
-          path: spec.default.config.httpHealthCheck.portName
-          value: http
+          path: spec.default.config.httpHealthCheck.port
+          value: 8080
       - equal:
           path: spec.default.config.httpHealthCheck.requestPath
           value: /actuator/health/readiness

--- a/charts/planr-tools/values.yaml
+++ b/charts/planr-tools/values.yaml
@@ -215,6 +215,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    # port:
-    portName: http
+    port: 8080
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/actuator/health/readiness"

--- a/charts/sophora-admin-dashboard/Chart.yaml
+++ b/charts/sophora-admin-dashboard/Chart.yaml
@@ -13,8 +13,8 @@ icon: https://subshell.com/logos/admindashboard104~1x1.1683631966185.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.0
+version: 1.10.1
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Breaking change: The `ingress.enabled` value is now set to `false` by default. If you want to enable the ingress, set it to `true` in your values.yaml."
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"

--- a/charts/sophora-admin-dashboard/values.yaml
+++ b/charts/sophora-admin-dashboard/values.yaml
@@ -264,6 +264,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    # port:
-    portName: http
+    port: 80
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/"

--- a/charts/sophora-cluster-common/Chart.yaml
+++ b/charts/sophora-cluster-common/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-cluster-common
 description: A Helm chart containing some common resources useful for Sophora cloud setups
 type: application
-version: 1.7.0
+version: 1.7.1
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added support for GRPCRoute, gRPC HTTPRoute, and GCP gRPC HealthCheckPolicy resources"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 appVersion: "4"
 sources:

--- a/charts/sophora-cluster-common/values.yaml
+++ b/charts/sophora-cluster-common/values.yaml
@@ -203,7 +203,9 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: http
+    port: 1196
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/status/ready"
   grpcHealthCheck:
     enabled: false

--- a/charts/sophora-image-access-service/Chart.yaml
+++ b/charts/sophora-image-access-service/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.9.3
+version: 1.9.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-image-access-service/values.yaml
+++ b/charts/sophora-image-access-service/values.yaml
@@ -162,5 +162,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: metrics
+    port: 8081
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: metrics
     path: "/actuator/health"

--- a/charts/sophora-image-ai/Chart.yaml
+++ b/charts/sophora-image-ai/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-image-ai
 description: Sophora Image AI
 type: application
-version: 2.5.3
+version: 2.5.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 appVersion: 5.1.0
 sources:

--- a/charts/sophora-importer/Chart.yaml
+++ b/charts/sophora-importer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.3
+version: 2.10.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-importer/values.yaml
+++ b/charts/sophora-importer/values.yaml
@@ -180,5 +180,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: main
+    port: 80
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: main
     path: "/actuator/health/readiness"

--- a/charts/sophora-indexing-service/Chart.yaml
+++ b/charts/sophora-indexing-service/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-indexing-service
 description: Sophora Indexing Service (SISI)
 type: application
-version: 1.10.3
+version: 1.10.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 appVersion: '5.4.1'
 sources:

--- a/charts/sophora-indexing-service/values.yaml
+++ b/charts/sophora-indexing-service/values.yaml
@@ -157,5 +157,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: http
+    port: 1837
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/health"

--- a/charts/sophora-metadata-supplier/Chart.yaml
+++ b/charts/sophora-metadata-supplier/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-metadata-supplier
 description: Sophora Metadata Supplier (SMS)
 type: application
-version: 1.7.3
+version: 1.7.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 appVersion: '4.14.0'
 sources:

--- a/charts/sophora-metadata-supplier/values.yaml
+++ b/charts/sophora-metadata-supplier/values.yaml
@@ -173,5 +173,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: http
+    port: 8080
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/actuator/health/readiness"

--- a/charts/sophora-server/Chart.yaml
+++ b/charts/sophora-server/Chart.yaml
@@ -15,13 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.0
+version: 3.7.1
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added GCP HealthCheckPolicy support for gRPC, use topLevelLabels for routes"
     - kind: changed
-      description: "breaking change: support multiple gRPC HTTPRoutes. Renamed `grpcHttproute/grpcRoute` to `grpcHttproutes/grpcRoutes`."
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-server/values.yaml
+++ b/charts/sophora-server/values.yaml
@@ -529,7 +529,9 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: http
+    port: 1196
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http
     path: "/status/ready"
   grpcHealthCheck:
     enabled: false

--- a/charts/sophora-youtube-connector/Chart.yaml
+++ b/charts/sophora-youtube-connector/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.3
+version: 1.7.4
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+    - kind: changed
+      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
   artifacthub.io/links: |
     - name: Documentation for the AV Tool
       url: https://subshell.com/docs/avtool/

--- a/charts/sophora-youtube-connector/values.yaml
+++ b/charts/sophora-youtube-connector/values.yaml
@@ -208,5 +208,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    portName: http-service
+    port: 8080
+    # note: Cannot use named port when using network endpoint group as backend.
+    # portName: http-service
     path: "/health"


### PR DESCRIPTION
fixes this error in GKE:
> [...] cannot use named port when using network endpoint group as backend.