### PR TITLE
[multiple] fixed port of GCP HealthCheckPolicy for headless services

### DIFF
--- a/charts/sophora-admin-dashboard/Chart.yaml
+++ b/charts/sophora-admin-dashboard/Chart.yaml
@@ -13,8 +13,8 @@ icon: https://subshell.com/logos/admindashboard104~1x1.1683631966185.png
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.10.2
+version: 1.10.3
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
+    - kind: fixed
+      description: "fixed port in GCP HealthCheckPolicy"

--- a/charts/sophora-admin-dashboard/values.yaml
+++ b/charts/sophora-admin-dashboard/values.yaml
@@ -34,11 +34,11 @@ configGenerator:
 
 service:
   # -- (string) k8s service type
-  type:
+  type: "ClusterIP"
   # -- (object) k8s service annotations
   annotations:
   # -- (string) k8s service cluster ip
-  clusterIP:
+  clusterIP: ""
   # -- (string) k8s service load balancer
   loadBalancerIP:
   # -- (int) k8s service port that will be exposed by the service
@@ -264,7 +264,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    port: 80
+    port: 8090
     # note: Cannot use named port when using network endpoint group as backend.
     # portName: http
     path: "/"

--- a/charts/sophora-importer/Chart.yaml
+++ b/charts/sophora-importer/Chart.yaml
@@ -15,11 +15,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.5
+version: 2.10.6
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
+    - kind: fixed
+      description: "fixed port in GCP HealthCheckPolicy"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-importer/values.yaml
+++ b/charts/sophora-importer/values.yaml
@@ -112,7 +112,7 @@ livenessProbe:
 
 service:
   annotations: {}
-  clusterIP:
+  clusterIP: ""
   type: ClusterIP
   httpPort: 80
 
@@ -180,7 +180,7 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    port: 80
+    port: 8082
     # note: Cannot use named port when using network endpoint group as backend.
     # portName: main
     path: "/actuator/health/readiness"

--- a/charts/sophora-indexing-service/Chart.yaml
+++ b/charts/sophora-indexing-service/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: sophora-indexing-service
 description: Sophora Indexing Service (SISI)
 type: application
-version: 1.10.5
+version: 1.10.6
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed GCP HealthCheckPolicy to use numeric port instead of named port by default"
+    - kind: fixed
+      description: "fixed path in GCP HealthCheckPolicy"
 
 appVersion: '5.4.1'
 sources:

--- a/charts/sophora-indexing-service/values.yaml
+++ b/charts/sophora-indexing-service/values.yaml
@@ -160,4 +160,4 @@ gcp:
     port: 1837
     # note: Cannot use named port when using network endpoint group as backend.
     # portName: http
-    path: "/health"
+    path: "/actuator/health/readiness"

--- a/charts/sophora-ugc-proxy/Chart.yaml
+++ b/charts/sophora-ugc-proxy/Chart.yaml
@@ -4,11 +4,11 @@ description: A Helm chart for Kubernetes to install Sophora UGC Proxy connected 
 
 type: application
 
-version: 1.3.3
+version: 1.3.4
 annotations:
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Fixed GCP HealthCheckPolicy logConfig field name from `enable` to `enabled`"
+      description: "fixed port in GCP HealthCheckPolicy"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/sophora-ugc-proxy/values.yaml
+++ b/charts/sophora-ugc-proxy/values.yaml
@@ -184,5 +184,5 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    port: 80
+    port: 8080
     path: "/actuator/health/readiness"

--- a/charts/sophora-ugc/Chart.yaml
+++ b/charts/sophora-ugc/Chart.yaml
@@ -15,11 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.0
+version: 2.8.0
 annotations:
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "fixed port in GCP HealthCheckPolicy"
     - kind: changed
-      description: "Extended httproute with multimedia backends"
+      description: "changed service type from LoadBalancer to ClusterIP"
   artifacthub.io/links: |
     - name: Documentation for Sophora UGC
       url: https://subshell.com/docs/ugc/

--- a/charts/sophora-ugc/templates/webapp-service.yaml
+++ b/charts/sophora-ugc/templates/webapp-service.yaml
@@ -10,7 +10,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.webapp.type }}
+  {{- if and (eq .Values.service.webapp.type "LoadBalancer") .Values.service.webapp.loadBalancerIP }}
   loadBalancerIP: {{ .Values.service.webapp.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: 80
       targetPort: {{ default 8080 (.Values.ugc.config.server).port }}

--- a/charts/sophora-ugc/values.yaml
+++ b/charts/sophora-ugc/values.yaml
@@ -14,7 +14,7 @@ service:
   jolokia:
     clusterIP: None
   webapp:
-    type: LoadBalancer
+    type: ClusterIP
     loadBalancerIP:
 
 ingress:
@@ -239,5 +239,5 @@ gcp:
   healthCheck:
     enabled: false
     logging: false
-    port: 80
+    port: 8080
     path: "/"


### PR DESCRIPTION
For headless service the health check accesses the container port directly instead of the service IP and port.

also fixed path in chart sophora-indexing-service