### PR TITLE
[sophora-image-access-service] remove GCLockerRetryAllocationCount (removed since Java 25) from javaOptions (UNSOI-4449)

### DIFF
--- a/charts/sophora-image-access-service/Chart.yaml
+++ b/charts/sophora-image-access-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.1
+version: 1.12.0
 annotations:
   artifacthub.io/changes: |
     - kind: changed

--- a/charts/sophora-image-access-service/Chart.yaml
+++ b/charts/sophora-image-access-service/Chart.yaml
@@ -18,8 +18,8 @@ type: application
 version: 1.11.1
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: "Added extraDeploy to additionally deploy custom resources"
+    - kind: changed
+      description: "Removed '-XX:GCLockerRetryAllocationCount=20' from the default javaOptions for compatibility with Java 25 (Sophora 6)"
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/sophora-image-access-service/values.yaml
+++ b/charts/sophora-image-access-service/values.yaml
@@ -7,7 +7,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: sophora-image-access-service
 
-javaOptions: "-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0 -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -XX:+UnlockDiagnosticVMOptions -XX:GCLockerRetryAllocationCount=20"
+javaOptions: "-XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=60.0 -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem -XX:+UnlockDiagnosticVMOptions"
 
 timeZone: "Europe/Berlin"
 


### PR DESCRIPTION
=> https://support.subshell.com/browse/UNSOI-4449